### PR TITLE
fix: in the model create dialog, always defaults to either a model name

### DIFF
--- a/components/model/CreateDialog.vue
+++ b/components/model/CreateDialog.vue
@@ -95,7 +95,7 @@ const hostAppStore = useHostAppStore()
 const { activeAccount } = storeToRefs(accountStore)
 
 const accountId = computed(() => activeAccount.value.accountInfo.id)
-const newModelName = ref<string>()
+const newModelName = ref<string>(hostAppStore.documentInfo?.name ?? 'unnamed model')
 const errorMessage = ref<WorkspacePermissionMessage>()
 
 const toggleDialog = () => {


### PR DESCRIPTION
Always defaults to a prefilled value in the model creation dialog. Specifically:

Unnamed model: 

![Screenshot 2025-05-20 180009](https://github.com/user-attachments/assets/e87135e1-1930-4fcc-acc1-ea3d2fd782d9)

Model with an actual name:

<img width="1280" alt="Screenshot 2025-05-20 1757012222" src="https://github.com/user-attachments/assets/e2671870-c355-40c4-a7bf-6eaaf491f0b7" />

This way the create button can be just clicked and things will just work OOTB. This is not visible in the screenshots well, but the text in there is no longer a placeholder, but actual text. 