### PR TITLE
fix(update): remove toast for update

### DIFF
--- a/components/common/UpdateAlert.vue
+++ b/components/common/UpdateAlert.vue
@@ -7,7 +7,7 @@
     color="neutral"
     size="xs"
     hide-icon
-    class="mb-2 mt-1"
+    class="mt-1"
   >
     <template #description>
       <div class="flex items-center">

--- a/lib/core/composables/updateConnector.ts
+++ b/lib/core/composables/updateConnector.ts
@@ -1,6 +1,5 @@
 import type { ToastNotification } from '@speckle/ui-components'
 import { ToastNotificationType } from '@speckle/ui-components'
-import { useConfigStore } from '~/store/config'
 import { useHostAppStore } from '~/store/hostApp'
 
 type Versions = {
@@ -18,31 +17,13 @@ export type Version = {
 
 export function useUpdateConnector() {
   const hostApp = useHostAppStore()
-  const config = useConfigStore()
-  const { $openUrl } = useNuxtApp()
 
   const versions = ref<Version[]>([])
   const latestAvailableVersion = ref<Version | null>(null)
 
-  const isUpToDate = computed(
-    () => hostApp.connectorVersion === latestAvailableVersion.value?.Number
-  )
-
   async function checkUpdate() {
     try {
       await getVersions()
-      if (!isUpToDate.value && !config.isDevMode) {
-        const notification: ToastNotification = {
-          type: ToastNotificationType.Success,
-          title: `New connector update available`,
-          description: latestAvailableVersion.value?.Number.replace('+0', ''), // TODO: currently versions end with "+0" Alan will have a look
-          cta: {
-            title: `Update`,
-            onClick: () => downloadLatestVersion()
-          }
-        }
-        hostApp.setNotification(notification)
-      }
     } catch (e) {
       console.error(e)
       const notification: ToastNotification = {
@@ -72,10 +53,6 @@ export function useUpdateConnector() {
     versions.value = sortedVersions
     latestAvailableVersion.value = sortedVersions[0]
     hostApp.setLatestAvailableVersion(sortedVersions[0])
-  }
-
-  function downloadLatestVersion() {
-    $openUrl(latestAvailableVersion.value?.Url as string)
   }
 
   return { checkUpdate }


### PR DESCRIPTION
initially we only had toast notification, then UpdateAlert introduced by @didimitrie and now we do not need toast. deleted.

<img width="382" alt="Screenshot 2025-05-21 at 00 08 41" src="https://github.com/user-attachments/assets/0eae7a64-3c4c-44f6-944c-1f13265b1917" />
