### PR TITLE
Fix: hide receive button according to binding

### DIFF
--- a/components/header/NavBar.vue
+++ b/components/header/NavBar.vue
@@ -25,6 +25,7 @@
         </div>
         <div class="relative group flex items-center">
           <FormButton
+            v-if="app.$receiveBinding"
             v-tippy="'Load a model from Speckle into this file'"
             color="outline"
             size="sm"


### PR DESCRIPTION
Damn... We were enabled receive button for non-receiver connectors...

It was a question via intercom in Tekla that a dude was trying to receive in tekla but actually there is no receive binding