### PR TITLE
Fix: handle connectors that is not deployed by Speckle

### DIFF
--- a/components/header/NavBar.vue
+++ b/components/header/NavBar.vue
@@ -53,6 +53,7 @@
           {{ hostAppStore.connectorVersion }}
         </div>
         <HeaderButton
+          v-if="hostAppStore.isDistributedBySpeckle"
           v-tippy="'Documentation and help'"
           @click="
             app.$openUrl(

--- a/lib/core/composables/updateConnector.ts
+++ b/lib/core/composables/updateConnector.ts
@@ -2,6 +2,16 @@ import type { ToastNotification } from '@speckle/ui-components'
 import { ToastNotificationType } from '@speckle/ui-components'
 import { useHostAppStore } from '~/store/hostApp'
 
+export class UpdateError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'FetchError'
+
+    // Required when extending Error in TypeScript
+    Object.setPrototypeOf(this, new.target.prototype)
+  }
+}
+
 type Versions = {
   Versions: Version[]
 }
@@ -35,24 +45,39 @@ export function useUpdateConnector() {
   }
 
   async function getVersions() {
-    const response = await fetch(
-      `https://releases.speckle.dev/manager2/feeds/${hostApp.hostAppName?.toLowerCase()}-v3.json`,
-      {
-        method: 'GET'
+    try {
+      // End point to get list of versions that deployed by Speckle's pipeline
+      const response = await fetch(
+        `https://releases.speckle.dev/manager2/feeds/${hostApp.hostAppName?.toLowerCase()}-v3.json`,
+        {
+          method: 'GET'
+        }
+      )
+
+      if (!response.ok) {
+        // It is the only way to understand the connector is distributed by Speckle or not.
+        throw new UpdateError('Failed to fetch versions')
       }
-    )
 
-    if (!response.ok) {
-      throw new Error('Failed to fetch versions')
+      const data = (await response.json()) as unknown as Versions
+      const sortedVersions = data.Versions.sort(function (a: Version, b: Version) {
+        return new Date(b.Date).getTime() - new Date(a.Date).getTime()
+      })
+      versions.value = sortedVersions
+      latestAvailableVersion.value = sortedVersions[0]
+      hostApp.setLatestAvailableVersion(sortedVersions[0])
+    } catch (err) {
+      if (err instanceof TypeError && err.message === 'Failed to fetch') {
+        // When user has network issue in between, actually it is not so likely because regardless user need network to be able to render netlify page
+        throw new Error('Network error')
+      } else if (err instanceof UpdateError) {
+        // We set the flag to use it in relavant places, hide some documentation related buttons etc..
+        hostApp.setIsDistributedBySpeckle(false)
+      } else {
+        // Rest of the possibilites that we trigger toast
+        throw new Error('Unknown error occurred')
+      }
     }
-
-    const data = (await response.json()) as unknown as Versions
-    const sortedVersions = data.Versions.sort(function (a: Version, b: Version) {
-      return new Date(b.Date).getTime() - new Date(a.Date).getTime()
-    })
-    versions.value = sortedVersions
-    latestAvailableVersion.value = sortedVersions[0]
-    hostApp.setLatestAvailableVersion(sortedVersions[0])
   }
 
   return { checkUpdate }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -69,7 +69,10 @@
               </div>
             </div>
             <!-- TEMPORARY MESSAGE TO USER! will be deleted -->
-            <div class="mt-2 bg-highlight-1 rounded-md p-2">
+            <div
+              v-if="store.isDistributedBySpeckle"
+              class="mt-2 bg-highlight-1 rounded-md p-2"
+            >
               <h1
                 class="text-heading-sm w-full bg-gradient-to-r from-blue-500 via-blue-400 to-blue-600 inline-block py-1 text-transparent bg-clip-text"
               >

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -43,6 +43,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const accountsStore = useAccountStore()
   const { checkUpdate } = useUpdateConnector()
 
+  const isDistributedBySpeckle = ref<boolean>(true)
   const latestAvailableVersion = ref<Version | null>(null)
 
   const currentNotification = ref<Nullable<ToastNotification>>(null)
@@ -83,6 +84,10 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
   const setHostAppError = (error: Nullable<HostAppError>) => {
     hostAppError.value = error
+  }
+
+  const setIsDistributedBySpeckle = (val: boolean) => {
+    isDistributedBySpeckle.value = val
   }
 
   /**
@@ -734,6 +739,8 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     availableViews,
     navisworksAvailableSavedSets,
     availableSelectSendFilters,
+    isDistributedBySpeckle,
+    setIsDistributedBySpeckle,
     setNotification,
     setModelError,
     setLatestAvailableVersion,


### PR DESCRIPTION
When it is not distributed by us:

1. We do not throw toast by saying `No version found to check update!`

2. There is no `Documenation` button at the nav bar
![SketchUp_7ZUG1unG56](https://github.com/user-attachments/assets/22c5b1c0-eeb3-4eb6-8611-fd5f74bab3c3)

3. There is no message and `Getting started` button on home page
![SketchUp_Ssl9TuKfMD](https://github.com/user-attachments/assets/ab9d9b49-7e4b-4c67-af46-06a7fe6367a5)
