### PR TITLE
feat(rhino): add revit mapper UI for category assignment

### DIFF
--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -7,7 +7,7 @@ export const IRevitMapperBindingKey = 'revitMapperBinding'
 
 export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
   // Gets list of available Revit categories for the UI dropdown
-  getAvailableCategories: () => Promise<CategoryOption[]>
+  getAvailableCategories: () => Promise<Category[]>
 
   // Assigns selected objects to a specific Revit category
   assignToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
@@ -43,43 +43,43 @@ export interface CategoryMapping {
 export class MockedMapperBinding implements IRevitMapperBinding {
   private mockMappings: CategoryMapping[] = []
 
-  public async assignToCategory(
-    objectIds: string[],
-    categoryValue: string
-  ): Promise<void> {
+  public assignToCategory(objectIds: string[], categoryValue: string): Promise<void> {
     console.log('Mock: Assigning objects to category', { objectIds, categoryValue })
-    // Mock implementation
+    return Promise.resolve()
   }
 
-  public async getAvailableCategories(): Promise<CategoryOption[]> {
-    // Return a few mock categories for dev
-    return [
+  public getAvailableCategories(): Promise<Category[]> {
+    return Promise.resolve([
       { value: 'OST_Walls', label: 'Walls' },
       { value: 'OST_Floors', label: 'Floors' },
       { value: 'OST_Ceilings', label: 'Ceilings' },
       { value: 'OST_Columns', label: 'Columns' }
-    ]
+    ])
   }
 
-  public async clearCategoryAssignment(objectIds: string[]): Promise<void> {
+  public clearCategoryAssignment(objectIds: string[]): Promise<void> {
     console.log('Mock: Clearing category assignment', { objectIds })
+    return Promise.resolve()
   }
 
-  public async clearAllCategoryAssignments(): Promise<void> {
+  public clearAllCategoryAssignments(): Promise<void> {
     console.log('Mock: Clearing all assignments')
     this.mockMappings = []
+    return Promise.resolve()
   }
 
-  public async getCurrentMappings(): Promise<CategoryMapping[]> {
-    return this.mockMappings
+  public getCurrentMappings(): Promise<CategoryMapping[]> {
+    return Promise.resolve(this.mockMappings)
   }
 
-  public async showDevTools() {
+  public showDevTools(): Promise<void> {
     console.log('Braaaaa, no way!')
+    return Promise.resolve()
   }
 
-  public async openUrl(url: string) {
+  public openUrl(url: string): Promise<void> {
     window.open(url)
+    return Promise.resolve()
   }
 
   public on() {

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -1,0 +1,78 @@
+import type {
+  IBinding,
+  IBindingSharedEvents
+} from '~/lib/bindings/definitions/IBinding'
+
+export const IRevitMapperBindingKey = 'revitMapperBinding'
+
+export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
+  // Assign objects to a Revit category (i.e. add BuiltInCategory as prop)
+  assignToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
+
+  // Clear category assignment for specific objects
+  clearCategoryAssignment: (objectIds: string[]) => Promise<void>
+
+  // Clear all category assignments
+  clearAllCategoryAssignments: () => Promise<void>
+
+  // Get current mappings for all objects
+  getCurrentMappings: () => Promise<CategoryMapping[]>
+
+  // Get objects assigned to a specific category
+  getObjectsByCategory: (categoryValue: string) => Promise<string[]>
+}
+
+export interface IMapperBindingEvents extends IBindingSharedEvents {
+  // Notify when mappings change
+  mappingsChanged: (mappings: CategoryMapping[]) => void
+}
+
+export interface CategoryMapping {
+  categoryValue: string
+  categoryLabel: string
+  objectIds: string[]
+  objectCount: number
+}
+
+// Mock implementation for dev/testing
+export class MockedMapperBinding implements IRevitMapperBinding {
+  private mockMappings: CategoryMapping[] = []
+
+  public async assignToCategory(
+    objectIds: string[],
+    categoryValue: string
+  ): Promise<void> {
+    console.log('Mock: Assigning objects to category', { objectIds, categoryValue })
+    // Mock implementation
+  }
+
+  public async clearCategoryAssignment(objectIds: string[]): Promise<void> {
+    console.log('Mock: Clearing category assignment', { objectIds })
+  }
+
+  public async clearAllCategoryAssignments(): Promise<void> {
+    console.log('Mock: Clearing all assignments')
+    this.mockMappings = []
+  }
+
+  public async getCurrentMappings(): Promise<CategoryMapping[]> {
+    return this.mockMappings
+  }
+
+  public async getObjectsByCategory(categoryValue: string): Promise<string[]> {
+    const mapping = this.mockMappings.find((m) => m.categoryValue === categoryValue)
+    return mapping?.objectIds || []
+  }
+
+  public async showDevTools() {
+    console.log('Braaaaa, no way!')
+  }
+
+  public async openUrl(url: string) {
+    window.open(url)
+  }
+
+  public on() {
+    // Mock event handler
+  }
+}

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -27,7 +27,7 @@ export interface IMapperBindingEvents extends IBindingSharedEvents {
   mappingsChanged: (mappings: CategoryMapping[]) => void
 }
 
-export interface CategoryOption {
+export interface Category {
   value: string
   label: string
 }

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -20,9 +20,6 @@ export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
 
   // Gets all current mappings to show in the UI table
   getCurrentMappings: () => Promise<CategoryMapping[]>
-
-  // Get all objects assigned to a specific category
-  getObjectsByCategory: (categoryValue: string) => Promise<string[]>
 }
 
 export interface IMapperBindingEvents extends IBindingSharedEvents {
@@ -75,11 +72,6 @@ export class MockedMapperBinding implements IRevitMapperBinding {
 
   public async getCurrentMappings(): Promise<CategoryMapping[]> {
     return this.mockMappings
-  }
-
-  public async getObjectsByCategory(categoryValue: string): Promise<string[]> {
-    const mapping = this.mockMappings.find((m) => m.categoryValue === categoryValue)
-    return mapping?.objectIds || []
   }
 
   public async showDevTools() {

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -6,25 +6,33 @@ import type {
 export const IRevitMapperBindingKey = 'revitMapperBinding'
 
 export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
-  // Assign objects to a Revit category (i.e. add BuiltInCategory as prop)
+  // Gets list of available Revit categories for the UI dropdown
+  getAvailableCategories: () => Promise<CategoryOption[]>
+
+  // Assigns selected objects to a specific Revit category
   assignToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
 
-  // Clear category assignment for specific objects
+  // Removes category assignments from specific objects
   clearCategoryAssignment: (objectIds: string[]) => Promise<void>
 
-  // Clear all category assignments
+  // Removes all category assignments in the doc
   clearAllCategoryAssignments: () => Promise<void>
 
-  // Get current mappings for all objects
+  // Gets all current mappings to show in the UI table
   getCurrentMappings: () => Promise<CategoryMapping[]>
 
-  // Get objects assigned to a specific category
+  // Get all objects assigned to a specific category
   getObjectsByCategory: (categoryValue: string) => Promise<string[]>
 }
 
 export interface IMapperBindingEvents extends IBindingSharedEvents {
   // Notify when mappings change
   mappingsChanged: (mappings: CategoryMapping[]) => void
+}
+
+export interface CategoryOption {
+  value: string
+  label: string
 }
 
 export interface CategoryMapping {

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -54,6 +54,16 @@ export class MockedMapperBinding implements IRevitMapperBinding {
     // Mock implementation
   }
 
+  public async getAvailableCategories(): Promise<CategoryOption[]> {
+    // Return a few mock categories for dev
+    return [
+      { value: 'OST_Walls', label: 'Walls' },
+      { value: 'OST_Floors', label: 'Floors' },
+      { value: 'OST_Ceilings', label: 'Ceilings' },
+      { value: 'OST_Columns', label: 'Columns' }
+    ]
+  }
+
   public async clearCategoryAssignment(objectIds: string[]): Promise<void> {
     console.log('Mock: Clearing category assignment', { objectIds })
   }

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -59,6 +59,18 @@
                   </FormButton>
                 </div>
               </div>
+              <!--Revit Integration button (only if mapper binding exists)-->
+              <div v-if="app.$revitMapperBinding" class="mt-4">
+                <hr class="border-outline-2 mb-4" />
+                <FormButton
+                  v-tippy="Map objects to Revit categories"
+                  to="/revit-mapper"
+                  color="outline"
+                  full-width
+                >
+                  Revit Integration
+                </FormButton>
+              </div>
             </div>
             <div v-else>
               <div v-if="store.documentInfo?.message" class="text-foreground-2">

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -63,7 +63,7 @@
               <div v-if="app.$revitMapperBinding" class="mt-4">
                 <hr class="border-outline-2 mb-4" />
                 <FormButton
-                  v-tippy="Map objects to Revit categories"
+                  v-tippy="'Map objects to Revit categories'"
                   to="/revit-mapper"
                   color="outline"
                   full-width

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -123,6 +123,7 @@ const categoryOptions = ref<Category[]>([])
 // Selection store integration
 const selectionStore = useSelectionStore()
 const { selectionInfo, hasBinding: hasSelectionBinding } = storeToRefs(selectionStore)
+const { $revitMapperBinding } = useNuxtApp()
 
 // Reactive state
 const selectedCategory = ref<Category | null>(null)
@@ -224,8 +225,26 @@ const clearAllMappings = () => {
   // await app.$mapperBinding?.clearAllCategoryAssignments(allObjectIds)
 }
 
+const loadCategories = async () => {
+  try {
+    const categories = (await $revitMapperBinding?.getAvailableCategories()) || []
+
+    // Convert backend format to UI format
+    categoryOptions.value = categories.map((cat) => ({
+      value: cat.value,
+      label: cat.label
+    }))
+
+    console.log('Loaded categories from backend:', categoryOptions.value.length)
+  } catch (error) {
+    console.error('Failed to load categories:', error)
+    categoryOptions.value = []
+  }
+}
+
 // Initialize selection on mount
-onMounted(() => {
+onMounted(async () => {
+  await loadCategories()
   if (hasSelectionBinding.value) {
     selectionStore.refreshSelectionFromHostApp()
   }

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="flex flex-col space-y-2">
+    <div class="px-2 mt-2">
+      <FormButton to="/" size="sm" :icon-left="ArrowLeftIcon" class="my-2">
+        Home
+      </FormButton>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
+</script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -4,10 +4,49 @@
       <FormButton to="/" size="sm" :icon-left="ArrowLeftIcon" class="my-2">
         Home
       </FormButton>
+      <hr />
+    </div>
+    <hr />
+    <div class="px-2">
+      <p class="h5">Category</p>
+      <div class="space-y-2 my-2">
+        <div
+          v-for="category in availableCategories"
+          :key="category.value"
+          class="p-2 bg-foundation border rounded-lg cursor-pointer hover:bg-highlight-1 transition"
+          @click="selectCategory(category)"
+        >
+          <div class="flex justify-between items-center">
+            <span class="text-sm font-medium">{{ category.label }}</span>
+            <span class="text-xs text-foreground-2">
+              {{ category.objectCount }} objects in category
+            </span>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
+
+// Interface for category
+interface Category {
+  value: string
+  label: string
+  objectCount: number
+}
+
+// Hardcoded categories for now
+const availableCategories: Category[] = [
+  { value: 'OST_Walls', label: 'OST_Walls', objectCount: 0 },
+  { value: 'OST_Floors', label: 'OST_Floors', objectCount: 0 }
+]
+
+// Click handler / logging
+const selectCategory = (category: Category) => {
+  console.log('Selected category:', category.label)
+  console.log('Objects in category:', category.objectCount)
+}
 </script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -64,12 +64,12 @@
       <div class="space-y-2 my-2">
         <div
           v-for="mapping in mappings"
-          :key="mapping.category.value"
+          :key="mapping.categoryValue"
           class="p-3 bg-foundation border rounded-lg"
         >
           <div class="flex justify-between items-center">
             <div>
-              <div class="text-sm font-medium">{{ mapping.category.label }}</div>
+              <div class="text-sm font-medium">{{ mapping.categoryLabel }}</div>
               <div class="text-xs text-foreground-2">
                 {{ mapping.objectCount }} object{{
                   mapping.objectCount !== 1 ? 's' : ''
@@ -104,18 +104,10 @@
 import { storeToRefs } from 'pinia'
 import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
 import { useSelectionStore } from '~/store/selection'
-
-// Interfaces
-interface Category {
-  value: string
-  label: string
-}
-
-interface CategoryMapping {
-  category: Category
-  objectIds: string[]
-  objectCount: number
-}
+import type {
+  Category,
+  CategoryMapping
+} from '~/lib/bindings/definitions/IRevitMapperBinding'
 
 // Dynamic categories loaded from connector
 const categoryOptions = ref<Category[]>([])
@@ -155,7 +147,7 @@ const assignToCategory = async () => {
   const objectIds = selectionInfo.value.selectedObjectIds
   console.log('Assigning objects to category:', {
     category: selectedCategory.value,
-    objectIds: objectIds,
+    objectIds,
     count: objectIds.length
   })
 

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -7,7 +7,7 @@
       <hr />
     </div>
 
-    <!-- Step 1: Selection Mode -->
+    <!-- Step 1: Selection Mode (currently only support by selection) -->
     <div class="px-2">
       <p class="h5">Selection</p>
       <div class="space-y-2 my-2">
@@ -105,7 +105,7 @@ import { storeToRefs } from 'pinia'
 import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
 import { useSelectionStore } from '~/store/selection'
 
-// TypeScript interfaces
+// Interfaces
 interface Category {
   value: string
   label: string
@@ -117,7 +117,7 @@ interface CategoryMapping {
   objectCount: number
 }
 
-// Hardcoded Revit BuiltInCategory options
+// Hardcoded Revit BuiltInCategory options - this'll come from connector obviously
 const categoryOptions: Category[] = [
   { value: 'OST_Ceilings', label: 'Ceilings' },
   { value: 'OST_Columns', label: 'Columns' },

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -61,11 +61,11 @@ interface Category {
 
 // Hardcoded categories (for now)
 const availableCategories: Category[] = [
-  { value: 'OST_Walls', label: 'Walls', objectCount: 0 },
-  { value: 'OST_Floors', label: 'Floors', objectCount: 0 },
-  { value: 'OST_Roofs', label: 'Roofs', objectCount: 0 },
-  { value: 'OST_Doors', label: 'Doors', objectCount: 0 },
-  { value: 'OST_Windows', label: 'Windows', objectCount: 0 }
+  { value: 'OST_Columns', label: 'OST_Columns', objectCount: 0 },
+  { value: 'OST_CurtainGrids', label: 'OST_CurtainGrids', objectCount: 0 },
+  { value: 'OST_Floors', label: 'OST_Floors', objectCount: 0 },
+  { value: 'OST_Furniture', label: 'OST_Furniture', objectCount: 0 },
+  { value: 'OST_Walls', label: 'OST_Walls', objectCount: 0 }
 ]
 
 // Selection store integration

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -117,49 +117,8 @@ interface CategoryMapping {
   objectCount: number
 }
 
-// Hardcoded Revit BuiltInCategory options - this'll come from connector obviously
-const categoryOptions: Category[] = [
-  { value: 'OST_Ceilings', label: 'Ceilings' },
-  { value: 'OST_Columns', label: 'Columns' },
-  { value: 'OST_CurtainGrids', label: 'Curtain Grids' },
-  { value: 'OST_CurtainGridsCurtaSystem', label: 'Curtain Grids - Curtain System' },
-  { value: 'OST_CurtainGridsRoof', label: 'Curtain Grids - Roof' },
-  { value: 'OST_CurtainGridsSystem', label: 'Curtain Grids - System' },
-  { value: 'OST_CurtainGridsWall', label: 'Curtain Grids - Wall' },
-  { value: 'OST_Curtain_Systems', label: 'Curtain Systems' },
-  { value: 'OST_CurtainWallMullions', label: 'Curtain Wall Mullions' },
-  { value: 'OST_CurtainWallPanels', label: 'Curtain Wall Panels' },
-  { value: 'OST_Floors', label: 'Floors' },
-  { value: 'OST_Furniture', label: 'Furniture' },
-  { value: 'OST_FurnitureSystems', label: 'Furniture Systems' },
-  { value: 'OST_Roofs', label: 'Roofs' },
-  { value: 'OST_StackedWalls', label: 'Stacked Walls' },
-  { value: 'OST_Walls', label: 'Walls' },
-  // STRUCTURAL
-  { value: 'OST_StructuralColumns', label: 'Structural Columns' },
-  { value: 'OST_StructuralFoundation', label: 'Structural Foundation' },
-  { value: 'OST_StructuralFraming', label: 'Structural Framing' },
-  { value: 'OST_StructuralFramingSystem', label: 'Structural Framing System' },
-  { value: 'OST_StructuralTruss', label: 'Structural Truss' },
-  // MISC
-  { value: 'OST_Levels', label: 'Levels' },
-  { value: 'OST_Grids', label: 'Grids' },
-  { value: 'OST_Rooms', label: 'Rooms' },
-  { value: 'OST_Areas', label: 'Areas' },
-  // MEP
-  { value: 'OST_DuctCurves', label: 'Duct Curves' },
-  { value: 'OST_DuctSystem', label: 'Duct System' },
-  { value: 'OST_DuctFitting', label: 'Duct Fitting' },
-  { value: 'OST_PipeCurves', label: 'Pipe Curves' },
-  { value: 'OST_PipeCurvesCenterLine', label: 'Pipe Curves - Center Line' },
-  { value: 'OST_PipeSegments', label: 'Pipe Segments' },
-  { value: 'OST_PipeFitting', label: 'Pipe Fitting' },
-  { value: 'OST_Conduit', label: 'Conduit' },
-  { value: 'OST_ConduitFitting', label: 'Conduit Fitting' },
-  { value: 'OST_Cable', label: 'Cable' },
-  { value: 'OST_CableTray', label: 'Cable Tray' },
-  { value: 'OST_CableTrayFittin', label: 'Cable Tray Fitting' }
-]
+// Dynamic categories loaded from connector
+const categoryOptions = ref<Category[]>([])
 
 // Selection store integration
 const selectionStore = useSelectionStore()

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -24,29 +24,72 @@
           </div>
         </div>
       </div>
+      <div class="flex space-x-2">
+        <FormButton color="outline" class="flex-1" @click="assignToCategory()">
+          Assign to Category
+        </FormButton>
+        <FormButton color="outline" class="flex-1" @click="clearAllAssignments()">
+          Clear all assignments
+        </FormButton>
+      </div>
+    </div>
+    <hr />
+    <div class="px-2">
+      <p class="h5">Selected Filter</p>
+      <div class="space-y-2 my-2">
+        <div class="p-3 bg-primary/10 border border-primary/20 rounded-lg">
+          <div class="text-sm text-primary font-medium">
+            {{ selectionInfo?.objectIds?.length || 0 }} objects selected.
+          </div>
+        </div>
+      </div>
     </div>
   </div>
 </template>
 
 <script setup lang="ts">
+import { storeToRefs } from 'pinia'
 import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
+import { useSelectionStore } from '~/store/selection'
 
-// Interface for category
+// BuiltInCategory data structure
 interface Category {
   value: string
   label: string
   objectCount: number
 }
 
-// Hardcoded categories for now
+// Hardcoded categories (for now)
 const availableCategories: Category[] = [
-  { value: 'OST_Walls', label: 'OST_Walls', objectCount: 0 },
-  { value: 'OST_Floors', label: 'OST_Floors', objectCount: 0 }
+  { value: 'OST_Walls', label: 'Walls', objectCount: 0 },
+  { value: 'OST_Floors', label: 'Floors', objectCount: 0 },
+  { value: 'OST_Roofs', label: 'Roofs', objectCount: 0 },
+  { value: 'OST_Doors', label: 'Doors', objectCount: 0 },
+  { value: 'OST_Windows', label: 'Windows', objectCount: 0 }
 ]
 
-// Click handler / logging
+// Selection store integration
+const selectionStore = useSelectionStore()
+const { selectionInfo, hasBinding: hasSelectionBinding } = storeToRefs(selectionStore)
+
+// Category selection function
 const selectCategory = (category: Category) => {
   console.log('Selected category:', category.label)
   console.log('Objects in category:', category.objectCount)
+  // TODO: Call binding to select objects assigned to this category
+}
+
+// Object mapping function
+const assignToCategory = () => {
+  console.log('Assign to category clicked')
+  console.log('Selected objects:', selectionInfo.value?.objectIds || [])
+  // TODO: Show category picker, then call binding to assign
+}
+
+// Clear mapping function
+const clearAllAssignments = () => {
+  console.log('Clear assignments clicked')
+  console.log('Selected objects:', selectionInfo.value?.objectIds || [])
+  // TODO: Call binding to clear assignments
 }
 </script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -6,42 +6,95 @@
       </FormButton>
       <hr />
     </div>
-    <hr />
+
+    <!-- Step 1: Selection Mode -->
     <div class="px-2">
-      <p class="h5">Category</p>
+      <p class="h5">Selection</p>
       <div class="space-y-2 my-2">
-        <div
-          v-for="category in availableCategories"
-          :key="category.value"
-          class="p-2 bg-foundation border rounded-lg cursor-pointer hover:bg-highlight-1 transition"
-          @click="selectCategory(category)"
-        >
-          <div class="flex justify-between items-center">
-            <span class="text-sm font-medium">{{ category.label }}</span>
-            <span class="text-xs text-foreground-2">
-              {{ category.objectCount }} objects in category
-            </span>
+        <div class="space-y-2 p-2 bg-highlight-1 rounded-md text-body-xs">
+          <div v-if="(selectionInfo?.selectedObjectIds?.length || 0) === 0">
+            No objects selected, go ahead and select some from your model!
           </div>
+          <div v-else>{{ selectionInfo?.summary }}</div>
         </div>
       </div>
-      <div class="flex space-x-2">
-        <FormButton color="outline" class="flex-1" @click="assignToCategory()">
-          Assign to Category
-        </FormButton>
-        <FormButton color="outline" class="flex-1" @click="clearAllAssignments()">
-          Clear all assignments
+    </div>
+
+    <!-- Step 2: Category Selection (only shown when objects are selected) -->
+    <div v-if="hasObjectsSelected" class="px-2">
+      <p class="h5">Target Category</p>
+      <div class="space-y-2 my-2">
+        <FormSelectBase
+          v-model="selectedCategory"
+          name="categoryMapping"
+          placeholder="Select a category"
+          class="w-full"
+          fixed-height
+          size="sm"
+          :items="categoryOptions"
+          :allow-unset="false"
+          mount-menu-on-body
+          show-label
+        >
+          <template #something-selected="{ value }">
+            <span class="text-primary text-base text-sm">{{ value.label }}</span>
+          </template>
+          <template #option="{ item }">
+            <span class="text-base text-sm">{{ item.label }}</span>
+          </template>
+        </FormSelectBase>
+
+        <!-- Action button -->
+        <FormButton
+          color="primary"
+          class="w-full mt-2"
+          :disabled="!selectedCategory"
+          @click="assignToCategory()"
+        >
+          Apply Mapping
         </FormButton>
       </div>
     </div>
-    <hr />
-    <div class="px-2">
-      <p class="h5">Selected Filter</p>
+
+    <hr v-if="hasObjectsSelected" />
+
+    <!-- Step 3: Mappings Summary Table -->
+    <div v-if="mappings.length > 0" class="px-2">
+      <p class="h5">Current Mappings</p>
       <div class="space-y-2 my-2">
-        <div class="p-3 bg-primary/10 border border-primary/20 rounded-lg">
-          <div class="text-sm text-primary font-medium">
-            {{ selectionInfo?.objectIds?.length || 0 }} objects selected.
+        <div
+          v-for="mapping in mappings"
+          :key="mapping.category.value"
+          class="p-3 bg-foundation border rounded-lg"
+        >
+          <div class="flex justify-between items-center">
+            <div>
+              <div class="text-sm font-medium">{{ mapping.category.label }}</div>
+              <div class="text-xs text-foreground-2">
+                {{ mapping.objectCount }} object{{
+                  mapping.objectCount !== 1 ? 's' : ''
+                }}
+              </div>
+            </div>
+            <div class="flex space-x-2">
+              <FormButton
+                size="xs"
+                color="outline"
+                @click="selectMappedObjects(mapping)"
+              >
+                Select
+              </FormButton>
+              <FormButton size="xs" color="danger" @click="clearMapping(mapping)">
+                Clear
+              </FormButton>
+            </div>
           </div>
         </div>
+
+        <!-- Clear all button -->
+        <FormButton color="outline" class="w-full mt-2" @click="clearAllMappings()">
+          Clear All Mappings
+        </FormButton>
       </div>
     </div>
   </div>
@@ -52,44 +105,170 @@ import { storeToRefs } from 'pinia'
 import { ArrowLeftIcon } from '@heroicons/vue/20/solid'
 import { useSelectionStore } from '~/store/selection'
 
-// BuiltInCategory data structure
+// TypeScript interfaces
 interface Category {
   value: string
   label: string
+}
+
+interface CategoryMapping {
+  category: Category
+  objectIds: string[]
   objectCount: number
 }
 
-// Hardcoded categories (for now)
-const availableCategories: Category[] = [
-  { value: 'OST_Columns', label: 'OST_Columns', objectCount: 0 },
-  { value: 'OST_CurtainGrids', label: 'OST_CurtainGrids', objectCount: 0 },
-  { value: 'OST_Floors', label: 'OST_Floors', objectCount: 0 },
-  { value: 'OST_Furniture', label: 'OST_Furniture', objectCount: 0 },
-  { value: 'OST_Walls', label: 'OST_Walls', objectCount: 0 }
+// Hardcoded Revit BuiltInCategory options
+const categoryOptions: Category[] = [
+  { value: 'OST_Ceilings', label: 'Ceilings' },
+  { value: 'OST_Columns', label: 'Columns' },
+  { value: 'OST_CurtainGrids', label: 'Curtain Grids' },
+  { value: 'OST_CurtainGridsCurtaSystem', label: 'Curtain Grids - Curtain System' },
+  { value: 'OST_CurtainGridsRoof', label: 'Curtain Grids - Roof' },
+  { value: 'OST_CurtainGridsSystem', label: 'Curtain Grids - System' },
+  { value: 'OST_CurtainGridsWall', label: 'Curtain Grids - Wall' },
+  { value: 'OST_Curtain_Systems', label: 'Curtain Systems' },
+  { value: 'OST_CurtainWallMullions', label: 'Curtain Wall Mullions' },
+  { value: 'OST_CurtainWallPanels', label: 'Curtain Wall Panels' },
+  { value: 'OST_Floors', label: 'Floors' },
+  { value: 'OST_Furniture', label: 'Furniture' },
+  { value: 'OST_FurnitureSystems', label: 'Furniture Systems' },
+  { value: 'OST_Roofs', label: 'Roofs' },
+  { value: 'OST_StackedWalls', label: 'Stacked Walls' },
+  { value: 'OST_Walls', label: 'Walls' },
+  // STRUCTURAL
+  { value: 'OST_StructuralColumns', label: 'Structural Columns' },
+  { value: 'OST_StructuralFoundation', label: 'Structural Foundation' },
+  { value: 'OST_StructuralFraming', label: 'Structural Framing' },
+  { value: 'OST_StructuralFramingSystem', label: 'Structural Framing System' },
+  { value: 'OST_StructuralTruss', label: 'Structural Truss' },
+  // MISC
+  { value: 'OST_Levels', label: 'Levels' },
+  { value: 'OST_Grids', label: 'Grids' },
+  { value: 'OST_Rooms', label: 'Rooms' },
+  { value: 'OST_Areas', label: 'Areas' },
+  // MEP
+  { value: 'OST_DuctCurves', label: 'Duct Curves' },
+  { value: 'OST_DuctSystem', label: 'Duct System' },
+  { value: 'OST_DuctFitting', label: 'Duct Fitting' },
+  { value: 'OST_PipeCurves', label: 'Pipe Curves' },
+  { value: 'OST_PipeCurvesCenterLine', label: 'Pipe Curves - Center Line' },
+  { value: 'OST_PipeSegments', label: 'Pipe Segments' },
+  { value: 'OST_PipeFitting', label: 'Pipe Fitting' },
+  { value: 'OST_Conduit', label: 'Conduit' },
+  { value: 'OST_ConduitFitting', label: 'Conduit Fitting' },
+  { value: 'OST_Cable', label: 'Cable' },
+  { value: 'OST_CableTray', label: 'Cable Tray' },
+  { value: 'OST_CableTrayFittin', label: 'Cable Tray Fitting' }
 ]
 
 // Selection store integration
 const selectionStore = useSelectionStore()
 const { selectionInfo, hasBinding: hasSelectionBinding } = storeToRefs(selectionStore)
 
-// Category selection function
-const selectCategory = (category: Category) => {
-  console.log('Selected category:', category.label)
-  console.log('Objects in category:', category.objectCount)
-  // TODO: Call binding to select objects assigned to this category
-}
+// Reactive state
+const selectedCategory = ref<Category | null>(null)
+const mappings = ref<CategoryMapping[]>([])
 
-// Object mapping function
+// Computed properties
+const hasObjectsSelected = computed(
+  () => (selectionInfo.value?.selectedObjectIds?.length || 0) > 0
+)
+
+// Watch for selection changes to refresh from host app
+watch(
+  hasSelectionBinding,
+  (newValue) => {
+    if (newValue) {
+      selectionStore.refreshSelectionFromHostApp()
+    }
+  },
+  { immediate: true }
+)
+
+// Functions for mapping management
 const assignToCategory = () => {
-  console.log('Assign to category clicked')
-  console.log('Selected objects:', selectionInfo.value?.objectIds || [])
-  // TODO: Show category picker, then call binding to assign
+  if (!selectedCategory.value || !selectionInfo.value?.selectedObjectIds) {
+    console.warn('No category selected or no objects selected')
+    return
+  }
+
+  const objectIds = selectionInfo.value.selectedObjectIds
+  console.log('Assigning objects to category:', {
+    category: selectedCategory.value,
+    objectIds: objectIds,
+    count: objectIds.length
+  })
+
+  // Find existing mapping or create new one
+  const existingMappingIndex = mappings.value.findIndex(
+    (m) => m.category.value === selectedCategory.value!.value
+  )
+
+  if (existingMappingIndex >= 0) {
+    // Update existing mapping - merge object IDs
+    const existingMapping = mappings.value[existingMappingIndex]
+    const mergedObjectIds = [...new Set([...existingMapping.objectIds, ...objectIds])]
+    mappings.value[existingMappingIndex] = {
+      ...existingMapping,
+      objectIds: mergedObjectIds,
+      objectCount: mergedObjectIds.length
+    }
+  } else {
+    // Create new mapping
+    mappings.value.push({
+      category: selectedCategory.value,
+      objectIds: [...objectIds],
+      objectCount: objectIds.length
+    })
+  }
+
+  // TODO: Call binding to assign mapping to objects
+  // await app.$mapperBinding?.assignToCategory(objectIds, selectedCategory.value.value)
+
+  // Reset selection
+  selectedCategory.value = null
+
+  console.log('Updated mappings:', mappings.value)
 }
 
-// Clear mapping function
-const clearAllAssignments = () => {
-  console.log('Clear assignments clicked')
-  console.log('Selected objects:', selectionInfo.value?.objectIds || [])
-  // TODO: Call binding to clear assignments
+const selectMappedObjects = (mapping: CategoryMapping) => {
+  console.log('Selecting mapped objects:', mapping.objectIds)
+  // TODO: Call binding to select these specific objects in Rhino
+  // await app.$selectionBinding?.setSelection(mapping.objectIds)
 }
+
+const clearMapping = (mapping: CategoryMapping) => {
+  console.log('Clearing mapping for category:', mapping.category.label)
+
+  // Remove from mappings array
+  const index = mappings.value.findIndex(
+    (m) => m.category.value === mapping.category.value
+  )
+  if (index >= 0) {
+    mappings.value.splice(index, 1)
+  }
+
+  // TODO: Call binding to clear category assignment for these objects
+  // await app.$mapperBinding?.clearCategoryAssignment(mapping.objectIds)
+}
+
+const clearAllMappings = () => {
+  console.log('Clearing all mappings')
+
+  // Get all object IDs from all mappings
+  const allObjectIds = mappings.value.flatMap((m) => m.objectIds)
+
+  // Clear the mappings array
+  mappings.value = []
+
+  // TODO: Call binding to clear all category assignments
+  // await app.$mapperBinding?.clearAllCategoryAssignments(allObjectIds)
+}
+
+// Initialize selection on mount
+onMounted(() => {
+  if (hasSelectionBinding.value) {
+    selectionStore.refreshSelectionFromHostApp()
+  }
+})
 </script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -174,6 +174,9 @@ const selectMappedObjects = async (mapping: CategoryMapping) => {
 
 // === LIFECYCLE ===
 onMounted(async () => {
+  $revitMapperBinding?.on('mappingsChanged', (updatedMappings: CategoryMapping[]) => {
+    mappings.value = updatedMappings
+  })
   await loadCategories()
   await refreshMappings()
   if (hasSelectionBinding.value) {

--- a/plugins/00.bindings.ts
+++ b/plugins/00.bindings.ts
@@ -45,6 +45,12 @@ import {
 import type { ITopLevelExpectionHandlerBinding } from '~/lib/bindings/definitions/ITopLevelExceptionHandlerBinding'
 import { ITopLevelExpectionHandlerBindingKey } from '~/lib/bindings/definitions/ITopLevelExceptionHandlerBinding'
 
+import type { IRevitMapperBinding } from '~/lib/bindings/definitions/IRevitMapperBinding'
+import {
+  IRevitMapperBindingKey,
+  MockedMapperBinding
+} from '~/lib/bindings/definitions/IRevitMapperBinding'
+
 // Makes TS happy
 declare let globalThis: Record<string, unknown> & {
   CefSharp?: { BindObjectAsync: (name: string) => Promise<void> }
@@ -116,6 +122,11 @@ export default defineNuxtPlugin(async () => {
       ? await tryHoistBinding<ISelectionBinding>(ISelectionBindingKey)
       : hoistMockBinding(new MockedSelectionBinding(), ISendBindingKey)
 
+  const revitMapperBinding =
+    isRunningOnConnector || !isDev
+      ? await tryHoistBinding<IRevitMapperBinding>(IRevitMapperBindingKey)
+      : hoistMockBinding(new MockedMapperBinding(), IRevitMapperBindingKey)
+
   const topLevelExceptionHandlerBinding =
     await tryHoistBinding<ITopLevelExpectionHandlerBinding>(
       ITopLevelExpectionHandlerBindingKey
@@ -145,7 +156,8 @@ export default defineNuxtPlugin(async () => {
       selectionBinding,
       topLevelExceptionHandlerBinding,
       showDevTools,
-      openUrl
+      openUrl,
+      revitMapperBinding
     }
   }
 })


### PR DESCRIPTION
## Description
Adds the page for Rhino-to-Revit category mapper. Users can select objects in Rhino, assign them to Revit categories via dropdown, and manage current mappings through a table-like interface.

Related to [CNX-2183](https://linear.app/speckle/issue/CNX-2183/create-dui3-mapper-view) as part of [Interop Lite](https://linear.app/speckle/project/interop-lite-80ec82529c1a).

## User Value
Provides a (hopefully) easy interface for assigning Revit categories to Rhino objects as part of the interop lite workflow.

## Changes:
- Added `IRevitMapperBinding.ts`
- Added `revit-mapper.vue` page with category selection and mapping management

## Validation of changes:
