### PR TITLE
Fix(settings): warn user and force push them to refresh

### DIFF
--- a/components/model/CardBase.vue
+++ b/components/model/CardBase.vue
@@ -19,7 +19,7 @@
             "
             hide-text
             class=""
-            :disabled="!canEdit"
+            :disabled="!canEdit || isSettingsMissing"
             @click.stop="$emit('manual-publish-or-load')"
           ></FormButton>
         </div>
@@ -57,6 +57,16 @@
               </button>
             </template>
           </AutomateResultDialog>
+          <!-- To test missing settings -->
+          <!-- <FormButton
+            v-if="!isSettingsMissing"
+            v-tippy="'Refresh settings are needed'"
+            color="subtle"
+            :icon-left="TrashIcon"
+            hide-text
+            size="sm"
+            @click="deleteSettings"
+          /> -->
           <FormButton
             v-if="store.hostAppName !== 'navisworks' && store.hostAppName !== 'etabs'"
             v-tippy="'Highlight'"
@@ -337,6 +347,31 @@ const highlightModel = () => {
   app.$baseBinding.highlightModel(props.modelCard.modelCardId)
   trackEvent('DUI3 Action', { name: 'Highlight Model' }, props.modelCard.accountId)
 }
+
+const isSettingsMissing = computed(() =>
+  isSender.value ? isSendSettingsMissing.value : isReceiveSettingsMissing.value
+)
+
+const isSendSettingsMissing = computed(
+  () =>
+    isSender.value &&
+    store.sendSettings &&
+    store.sendSettings.length > 0 &&
+    !props.modelCard.settings
+)
+
+const isReceiveSettingsMissing = computed(
+  () =>
+    !isSender.value &&
+    store.receiveSettings &&
+    store.receiveSettings.length > 0 &&
+    !props.modelCard.settings
+)
+
+// To test missing settings
+// const deleteSettings = async () => {
+//   await store.patchModel(props.modelCard.modelCardId, { settings: undefined })
+// }
 
 const viewModel = () => {
   // previously with DUI2, it was Stream View but actually it is "Version View" now. Also having conflict with old/new terminology.

--- a/components/model/Receiver.vue
+++ b/components/model/Receiver.vue
@@ -19,7 +19,7 @@
         color="subtle"
         class="block text-foreground-2 hover:text-foreground overflow-hidden max-w-full !justify-start"
         full-width
-        :disabled="!!modelCard.progress || !canEdit"
+        :disabled="!!modelCard.progress || !canEdit || isReceiveSettingsMissing"
         @click.stop="openVersionsDialog = true"
       >
         <span>
@@ -58,6 +58,10 @@
       />
     </CommonDialog>
     <template #states>
+      <CommonModelNotification
+        v-if="isReceiveSettingsMissing"
+        :notification="receiveSettingsMissingNotification"
+      />
       <CommonModelNotification
         v-if="expiredNotification"
         :notification="expiredNotification"
@@ -119,6 +123,30 @@ const projectAccount = computed(() =>
 
 app.$baseBinding?.on('documentChanged', () => {
   openVersionsDialog.value = false
+})
+
+const isReceiveSettingsMissing = computed(
+  () =>
+    store.receiveSettings &&
+    store.receiveSettings.length > 0 &&
+    !props.modelCard.settings
+)
+
+const receiveSettingsMissingNotification = computed(() => {
+  const notification = {} as ModelCardNotification
+  notification.dismissible = false
+  notification.level = 'danger'
+  notification.text = 'Load settings are corrupted for some reason.'
+
+  notification.cta = {
+    name: 'Refresh',
+    action: async () => {
+      await store.patchModel(props.modelCard.modelCardId, {
+        settings: store.receiveSettings
+      })
+    }
+  }
+  return notification
 })
 
 const isExpired = computed(() => {


### PR DESCRIPTION
whenever the settings are missing on model cards, we warn users.

<img width="742" height="692" alt="image" src="https://github.com/user-attachments/assets/e7cdd5a8-e256-4540-aaca-00d432e26541" />
