### PR TITLE
feat(dui): layer mapping for revit integration in interop lite

### DIFF
--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -8,6 +8,7 @@ export const IRevitMapperBindingKey = 'revitMapperBinding'
 export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
   // Gets list of available Revit categories for the UI dropdown
   getAvailableCategories: () => Promise<Category[]>
+  getAvailableLayers: () => Promise<LayerOption[]>
 
   // Object methods
   assignObjectsToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
@@ -47,6 +48,11 @@ export interface LayerCategoryMapping {
   layerCount: number
 }
 
+export interface LayerOption {
+  id: string
+  name: string
+}
+
 // Mock implementation for dev/testing
 export class MockedMapperBinding implements IRevitMapperBinding {
   private mockMappings: CategoryMapping[] = []
@@ -65,6 +71,15 @@ export class MockedMapperBinding implements IRevitMapperBinding {
       { value: 'OST_Floors', label: 'Floors' },
       { value: 'OST_Ceilings', label: 'Ceilings' },
       { value: 'OST_Columns', label: 'Columns' }
+    ])
+  }
+
+  public getAvailableLayers(): Promise<LayerOption[]> {
+    return Promise.resolve([
+      { id: 'layer1', name: 'Ground Floor' },
+      { id: 'layer2', name: 'Ground Floor/Walls' },
+      { id: 'layer3', name: 'Ground Floor/Walls/Interior' },
+      { id: 'layer4', name: 'Second Floor' }
     ])
   }
 

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -83,6 +83,28 @@ export class MockedMapperBinding implements IRevitMapperBinding {
     return Promise.resolve(this.mockMappings)
   }
 
+  public assignLayerToCategory(
+    layerIds: string[],
+    categoryValue: string
+  ): Promise<void> {
+    console.log('Mock: Assigning layers to category', { layerIds, categoryValue })
+    return Promise.resolve()
+  }
+
+  public clearLayerCategoryAssignment(layerIds: string[]): Promise<void> {
+    console.log('Mock: Clearing layer category assignment', { layerIds })
+    return Promise.resolve()
+  }
+
+  public clearAllLayerCategoryAssignments(): Promise<void> {
+    console.log('Mock: Clearing all layer assignments')
+    return Promise.resolve()
+  }
+
+  public getCurrentLayerMappings(): Promise<LayerCategoryMapping[]> {
+    return Promise.resolve([])
+  }
+
   public showDevTools(): Promise<void> {
     console.log('Braaaaa, no way!')
     return Promise.resolve()

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -21,6 +21,10 @@ export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
   clearLayerCategoryAssignment: (layerIds: string[]) => Promise<void>
   clearAllLayerCategoryAssignments: () => Promise<void>
   getCurrentLayerMappings: () => Promise<LayerCategoryMapping[]>
+  getEffectiveObjectsForLayerMapping: (
+    layerIds: string[],
+    categoryValue: string
+  ) => Promise<string[]>
 }
 
 export interface IMapperBindingEvents extends IBindingSharedEvents {
@@ -118,6 +122,17 @@ export class MockedMapperBinding implements IRevitMapperBinding {
 
   public getCurrentLayerMappings(): Promise<LayerCategoryMapping[]> {
     return Promise.resolve([])
+  }
+
+  public getEffectiveObjectsForLayerMapping(
+    layerIds: string[],
+    categoryValue: string
+  ): Promise<string[]> {
+    console.log('Mock: Getting effective objects for layer mapping', {
+      layerIds,
+      categoryValue
+    })
+    return Promise.resolve(['obj1', 'obj2', 'obj3'])
   }
 
   public showDevTools(): Promise<void> {

--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -9,17 +9,17 @@ export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
   // Gets list of available Revit categories for the UI dropdown
   getAvailableCategories: () => Promise<Category[]>
 
-  // Assigns selected objects to a specific Revit category
-  assignToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
+  // Object methods
+  assignObjectsToCategory: (objectIds: string[], categoryValue: string) => Promise<void>
+  clearObjectsCategoryAssignment: (objectIds: string[]) => Promise<void>
+  clearAllObjectsCategoryAssignments: () => Promise<void>
+  getCurrentObjectsMappings: () => Promise<CategoryMapping[]>
 
-  // Removes category assignments from specific objects
-  clearCategoryAssignment: (objectIds: string[]) => Promise<void>
-
-  // Removes all category assignments in the doc
-  clearAllCategoryAssignments: () => Promise<void>
-
-  // Gets all current mappings to show in the UI table
-  getCurrentMappings: () => Promise<CategoryMapping[]>
+  // Layer methods
+  assignLayerToCategory: (layerIds: string[], categoryValue: string) => Promise<void>
+  clearLayerCategoryAssignment: (layerIds: string[]) => Promise<void>
+  clearAllLayerCategoryAssignments: () => Promise<void>
+  getCurrentLayerMappings: () => Promise<LayerCategoryMapping[]>
 }
 
 export interface IMapperBindingEvents extends IBindingSharedEvents {
@@ -39,11 +39,22 @@ export interface CategoryMapping {
   objectCount: number
 }
 
+export interface LayerCategoryMapping {
+  categoryValue: string
+  categoryLabel: string
+  layerIds: string[]
+  layerNames: string[]
+  layerCount: number
+}
+
 // Mock implementation for dev/testing
 export class MockedMapperBinding implements IRevitMapperBinding {
   private mockMappings: CategoryMapping[] = []
 
-  public assignToCategory(objectIds: string[], categoryValue: string): Promise<void> {
+  public assignObjectsToCategory(
+    objectIds: string[],
+    categoryValue: string
+  ): Promise<void> {
     console.log('Mock: Assigning objects to category', { objectIds, categoryValue })
     return Promise.resolve()
   }
@@ -57,18 +68,18 @@ export class MockedMapperBinding implements IRevitMapperBinding {
     ])
   }
 
-  public clearCategoryAssignment(objectIds: string[]): Promise<void> {
+  public clearObjectsCategoryAssignment(objectIds: string[]): Promise<void> {
     console.log('Mock: Clearing category assignment', { objectIds })
     return Promise.resolve()
   }
 
-  public clearAllCategoryAssignments(): Promise<void> {
+  public clearAllObjectsCategoryAssignments(): Promise<void> {
     console.log('Mock: Clearing all assignments')
     this.mockMappings = []
     return Promise.resolve()
   }
 
-  public getCurrentMappings(): Promise<CategoryMapping[]> {
+  public getCurrentObjectsMappings(): Promise<CategoryMapping[]> {
     return Promise.resolve(this.mockMappings)
   }
 

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -13,7 +13,7 @@
       <div class="space-y-2 my-2">
         <div>
           <FormSelectBase
-            v-model="selectedMappingMode"
+            :model-value="selectedMappingMode"
             name="mappingMode"
             label="Mapping mode"
             class="w-full"
@@ -22,6 +22,7 @@
             :items="mappingModeOptions"
             :allow-unset="false"
             mount-menu-on-body
+            @update:model-value="handleModeChange"
           >
             <template #something-selected="{ value }">
               <span class="text-primary text-base text-sm">{{ value }}</span>
@@ -70,7 +71,7 @@
                         ? `${value.length} layer${
                             value.length !== 1 ? 's' : ''
                           } selected`
-                        : value.name
+                        : value?.name
                     }}
                   </span>
                 </template>
@@ -106,7 +107,6 @@
     <div v-if="hasTargetsSelected" class="px-2">
       <p class="h5">Target Category</p>
       <div class="space-y-2 my-2">
-        <!-- Flex layout with dropdown and apply button side by side -->
         <div class="flex space-x-2">
           <div class="flex-1">
             <FormSelectBase
@@ -126,7 +126,7 @@
             >
               <template #something-selected="{ value }">
                 <span class="text-primary text-xs">
-                  {{ Array.isArray(value) ? value[0]?.label : value.label }}
+                  {{ Array.isArray(value) ? value[0]?.label : value?.label }}
                 </span>
               </template>
               <template #option="{ item }">
@@ -135,7 +135,7 @@
             </FormSelectBase>
           </div>
 
-          <!-- Apply button - same height as dropdown -->
+          <!-- Apply button -->
           <FormButton
             color="primary"
             size="sm"
@@ -151,55 +151,139 @@
 
     <hr v-if="hasTargetsSelected" />
 
-    <!-- Step 3: Mappings Summary Table -->
-    <div v-if="mappings.length > 0" class="px-2">
+    <!-- Step 3: Mappings Summary Tables -->
+    <div
+      v-if="currentMappings.length > 0 || currentLayerMappings.length > 0"
+      class="px-2"
+    >
       <p class="h5">Current Mappings</p>
 
-      <!-- Only mapping items get space-y -->
-      <div class="space-y-1 my-2">
-        <div
-          v-for="mapping in mappings"
-          :key="mapping.categoryValue"
-          class="py-1 px-2 bg-foundation border rounded-lg"
-        >
-          <div class="flex justify-between items-center">
-            <div class="text-sm font-medium grow">{{ mapping.categoryLabel }}</div>
+      <!-- Object Mappings Section -->
+      <div v-if="currentMappings.length > 0" class="my-2">
+        <div class="text-sm font-medium text-foreground-2 mb-1">Object Mappings</div>
+        <div class="space-y-1">
+          <div
+            v-for="mapping in currentMappings"
+            :key="mapping.categoryValue"
+            class="py-1 px-2 bg-foundation border rounded-lg"
+          >
+            <div class="flex justify-between items-center">
+              <div class="text-sm font-medium grow">{{ mapping.categoryLabel }}</div>
 
-            <div class="flex space-x-1">
-              <div
-                class="flex justify-center items-center text-xs text-foreground-2 mr-1"
-              >
-                {{ mapping.objectCount }} object{{
-                  mapping.objectCount !== 1 ? 's' : ''
-                }}
+              <div class="flex space-x-1">
+                <div
+                  class="flex justify-center items-center text-xs text-foreground-2 mr-1"
+                >
+                  {{ mapping.objectCount }} object{{
+                    mapping.objectCount !== 1 ? 's' : ''
+                  }}
+                </div>
+                <FormButton
+                  size="sm"
+                  color="outline"
+                  :icon-left="CursorArrowRaysIcon"
+                  hide-text
+                  @click="selectMappedObjects(mapping)"
+                />
+                <FormButton
+                  class="!px-1.5"
+                  size="sm"
+                  color="outline"
+                  @click="clearMapping(mapping)"
+                >
+                  <TrashIcon class="w-3 h-3" />
+                </FormButton>
               </div>
-              <FormButton
-                size="sm"
-                color="outline"
-                :icon-left="CursorArrowRaysIcon"
-                hide-text
-                @click="selectMappedObjects(mapping)"
-              />
-              <FormButton
-                class="!px-1.5"
-                size="sm"
-                color="outline"
-                @click="clearMapping(mapping)"
-              >
-                <TrashIcon class="w-3 h-3" />
-              </FormButton>
             </div>
           </div>
         </div>
       </div>
 
-      <!-- Clear all button separated, with custom margin -->
+      <!-- Layer Mappings Section -->
+      <div v-if="currentLayerMappings.length > 0" class="my-2">
+        <div class="text-sm font-medium text-foreground-2 mb-1">Layer Mappings</div>
+        <div class="space-y-1">
+          <div
+            v-for="layerMapping in currentLayerMappings"
+            :key="layerMapping.categoryValue"
+            class="py-1 px-2 bg-foundation border rounded-lg"
+          >
+            <div class="flex justify-between items-center">
+              <div class="text-sm font-medium grow">
+                {{ layerMapping.categoryLabel }}
+              </div>
+
+              <div class="flex space-x-1">
+                <div
+                  class="flex justify-center items-center text-xs text-foreground-2 mr-1"
+                >
+                  {{ layerMapping.layerCount }} layer{{
+                    layerMapping.layerCount !== 1 ? 's' : ''
+                  }}
+                </div>
+                <!-- Tooltip showing layer names -->
+                <FormButton
+                  v-tippy="`Layers: ${layerMapping.layerNames.join(', ')}`"
+                  size="sm"
+                  color="outline"
+                  :icon-left="CursorArrowRaysIcon"
+                  hide-text
+                  @click="selectMappedLayers(layerMapping)"
+                />
+                <FormButton
+                  class="!px-1.5"
+                  size="sm"
+                  color="outline"
+                  @click="clearLayerMapping(layerMapping)"
+                >
+                  <TrashIcon class="w-3 h-3" />
+                </FormButton>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Clear all button -->
       <div class="flex justify-end">
-        <FormButton size="sm" color="danger" @click="clearAllMappings()">
-          Clear All
+        <FormButton
+          v-if="selectedMappingMode === 'Selection' && currentMappings.length > 0"
+          size="sm"
+          color="danger"
+          @click="clearAllMappings()"
+        >
+          Clear All Objects
+        </FormButton>
+        <FormButton
+          v-if="selectedMappingMode === 'Layer' && currentLayerMappings.length > 0"
+          size="sm"
+          color="danger"
+          @click="clearAllLayerMappings()"
+        >
+          Clear All Layers
         </FormButton>
       </div>
     </div>
+
+    <!-- Mode Confirmation Dialog -->
+    <CommonDialog
+      v-model:open="showModeConfirmDialog"
+      title="Switch Mapping Mode"
+      fullscreen="none"
+    >
+      <div class="text-sm text-foreground">
+        {{ conflictMessage }}
+      </div>
+
+      <div class="mt-4 flex justify-end space-x-2">
+        <FormButton size="sm" color="outline" @click="cancelModeChange()">
+          Cancel
+        </FormButton>
+        <FormButton size="sm" color="danger" @click="confirmModeChange()">
+          Clear & Switch
+        </FormButton>
+      </div>
+    </CommonDialog>
   </div>
 </template>
 
@@ -229,6 +313,12 @@ const mappings = ref<CategoryMapping[]>([])
 // Layer-specific state
 const selectedLayers = ref<LayerOption[]>([])
 const layerOptions = ref<LayerOption[]>([])
+const layerMappings = ref<LayerCategoryMapping[]>([])
+
+// Mode switching state
+const showModeConfirmDialog = ref(false)
+const pendingMode = ref<string>('')
+const conflictMessage = ref('')
 
 // === TYPES ===
 interface LayerOption {
@@ -246,6 +336,15 @@ const hasTargetsSelected = computed(() => {
   return false
 })
 
+// Show appropriate mappings based on current mode
+const currentMappings = computed(() => {
+  return selectedMappingMode.value === 'Selection' ? mappings.value : []
+})
+
+const currentLayerMappings = computed(() => {
+  return selectedMappingMode.value === 'Layer' ? layerMappings.value : []
+})
+
 // === METHODS ===
 const app = useNuxtApp()
 const { $revitMapperBinding, $baseBinding } = app
@@ -258,6 +357,60 @@ const searchFilterPredicate = (item: Category, query: string) => {
 // Search predicate for layer dropdown
 const layerSearchFilterPredicate = (item: LayerOption, query: string) => {
   return item.name.toLowerCase().includes(query.toLowerCase())
+}
+
+// Handle mode changes with conflict checking
+const handleModeChange = (newMode: string) => {
+  // If switching to same mode, do nothing
+  if (newMode === selectedMappingMode.value) return
+
+  // Check for conflicts - ONLY show dialog if there are existing mappings
+  if (newMode === 'Layer' && mappings.value.length > 0) {
+    // Switching to Layer mode with existing object mappings
+    pendingMode.value = newMode
+    conflictMessage.value = `Switching to Layer mode will clear all current object mappings. Continue?`
+    showModeConfirmDialog.value = true
+  } else if (newMode === 'Selection' && layerMappings.value.length > 0) {
+    // Switching to Selection mode with existing layer mappings
+    pendingMode.value = newMode
+    conflictMessage.value = `Switching to Selection mode will clear all current layer mappings. Continue?`
+    showModeConfirmDialog.value = true
+  } else {
+    // No conflicts, switch directly (no existing mappings or switching to same mode)
+    selectedMappingMode.value = newMode
+  }
+}
+
+// Cancel mode change
+const cancelModeChange = () => {
+  showModeConfirmDialog.value = false
+  pendingMode.value = ''
+  conflictMessage.value = ''
+  // FormSelectBase will remain at current value since we didn't update selectedMappingMode
+}
+
+// Confirm mode change and clear conflicting mappings
+const confirmModeChange = async () => {
+  try {
+    if (pendingMode.value === 'Layer') {
+      // Clear all object mappings before switching to Layer mode
+      await $revitMapperBinding?.clearAllObjectsCategoryAssignments()
+    } else if (pendingMode.value === 'Selection') {
+      // Clear all layer mappings before switching to Selection mode
+      await $revitMapperBinding?.clearAllLayerCategoryAssignments()
+    }
+
+    // Switch mode
+    selectedMappingMode.value = pendingMode.value
+    await refreshMappings()
+
+    // Close dialog
+    showModeConfirmDialog.value = false
+    pendingMode.value = ''
+    conflictMessage.value = ''
+  } catch (error) {
+    console.error('Failed to clear mappings during mode switch:', error)
+  }
 }
 
 // Assign selected objects/layers to the chosen category
@@ -284,7 +437,7 @@ const assignToCategory = async () => {
   }
 }
 
-// Clear a specific mapping
+// Clear a specific object mapping
 const clearMapping = async (mapping: CategoryMapping) => {
   try {
     await $revitMapperBinding?.clearObjectsCategoryAssignment(mapping.objectIds)
@@ -294,13 +447,33 @@ const clearMapping = async (mapping: CategoryMapping) => {
   }
 }
 
-// Clear all mappings
+// Clear all object mappings
 const clearAllMappings = async () => {
   try {
     await $revitMapperBinding?.clearAllObjectsCategoryAssignments()
     await refreshMappings()
   } catch (error) {
     console.error('Failed to clear all mappings:', error)
+  }
+}
+
+// Clear a specific layer mapping
+const clearLayerMapping = async (layerMapping: LayerCategoryMapping) => {
+  try {
+    await $revitMapperBinding?.clearLayerCategoryAssignment(layerMapping.layerIds)
+    await refreshMappings()
+  } catch (error) {
+    console.error('Failed to clear layer mapping:', error)
+  }
+}
+
+// Clear all layer mappings
+const clearAllLayerMappings = async () => {
+  try {
+    await $revitMapperBinding?.clearAllLayerCategoryAssignments()
+    await refreshMappings()
+  } catch (error) {
+    console.error('Failed to clear all layer mappings:', error)
   }
 }
 
@@ -313,25 +486,60 @@ const selectMappedObjects = async (mapping: CategoryMapping) => {
   }
 }
 
+// Select mapped layers (highlight objects on those layers)
+const selectMappedLayers = async (layerMapping: LayerCategoryMapping) => {
+  try {
+    const effectiveObjectIds =
+      (await $revitMapperBinding?.getEffectiveObjectsForLayerMapping(
+        layerMapping.layerIds,
+        layerMapping.categoryValue
+      )) || []
+
+    if (effectiveObjectIds.length > 0) {
+      await $baseBinding?.highlightObjects(effectiveObjectIds)
+    }
+  } catch (error) {
+    console.error('Failed to highlight effective objects:', error)
+  }
+}
+
 // Load available categories, layers, and current mappings
 const loadData = async () => {
   try {
-    const [categories, currentMappings, layers] = await Promise.all([
-      $revitMapperBinding?.getAvailableCategories() || [],
-      $revitMapperBinding?.getCurrentObjectsMappings() || [],
-      loadAvailableLayers()
-    ])
+    const [categories, currentMappings, currentLayerMappings, layers] =
+      await Promise.all([
+        $revitMapperBinding?.getAvailableCategories() || [],
+        $revitMapperBinding?.getCurrentObjectsMappings() || [],
+        $revitMapperBinding?.getCurrentLayerMappings() || [],
+        loadAvailableLayers()
+      ])
     categoryOptions.value = categories
     mappings.value = currentMappings
+    layerMappings.value = currentLayerMappings
     layerOptions.value = layers
   } catch (error) {
     console.error('Failed to load mapper data:', error)
   }
 }
 
-// Load available layers from Rhino doc
+// Refresh both object and layer mappings
+const refreshMappings = async () => {
+  try {
+    const [currentMappings, currentLayerMappings] = await Promise.all([
+      $revitMapperBinding?.getCurrentObjectsMappings() || [],
+      $revitMapperBinding?.getCurrentLayerMappings() || []
+    ])
+    mappings.value = currentMappings
+    layerMappings.value = currentLayerMappings
+  } catch (error) {
+    console.error('Failed to refresh mappings:', error)
+  }
+}
+
+// Load available layers from Rhino document
 const loadAvailableLayers = async (): Promise<LayerOption[]> => {
   try {
+    // Call the backend method to get available layers
     const layers = (await $revitMapperBinding?.getAvailableLayers()) || []
     return layers
   } catch (error) {
@@ -340,14 +548,14 @@ const loadAvailableLayers = async (): Promise<LayerOption[]> => {
   }
 }
 
-// Refresh just the mappings
-const refreshMappings = async () => {
+// Refresh just the layer mappings
+const refreshLayerMappings = async () => {
   try {
-    const currentMappings =
-      (await $revitMapperBinding?.getCurrentObjectsMappings()) || []
-    mappings.value = currentMappings
+    const currentLayerMappings =
+      (await $revitMapperBinding?.getCurrentLayerMappings()) || []
+    layerMappings.value = currentLayerMappings
   } catch (error) {
-    console.error('Failed to refresh mappings:', error)
+    console.error('Failed to refresh layer mappings:', error)
   }
 }
 
@@ -355,9 +563,11 @@ const refreshMappings = async () => {
 onMounted(() => {
   loadData()
 
-  // Listen for mappings changes from backend with null safety
+  // Listen for mappings changes from backend (with null safety)
   $revitMapperBinding?.on('mappingsChanged', (newMappings: CategoryMapping[]) => {
     mappings.value = newMappings
+    // Also refresh layer mappings when backend notifies of changes
+    refreshLayerMappings()
   })
 })
 </script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -48,7 +48,7 @@
           <div class="space-y-2 my-2">
             <!-- Multi-select layer dropdown -->
             <div>
-              <FormSelectBase
+              <FormSelectMulti
                 v-model="selectedLayers"
                 name="layerSelection"
                 label="Select layers"
@@ -57,7 +57,6 @@
                 size="sm"
                 :items="layerOptions"
                 :allow-unset="false"
-                :multiple="true"
                 by="id"
                 search
                 :search-placeholder="'Search layers...'"
@@ -67,18 +66,14 @@
                 <template #something-selected="{ value }">
                   <span class="text-primary text-base text-sm">
                     {{
-                      Array.isArray(value)
-                        ? `${value.length} layer${
-                            value.length !== 1 ? 's' : ''
-                          } selected`
-                        : value?.name
+                      `${value.length} layer${value.length !== 1 ? 's' : ''} selected`
                     }}
                   </span>
                 </template>
                 <template #option="{ item }">
                   <span class="text-base text-sm">{{ item.name }}</span>
                 </template>
-              </FormSelectBase>
+              </FormSelectMulti>
             </div>
 
             <!-- Layer selection summary -->
@@ -428,6 +423,7 @@ const assignToCategory = async () => {
         selectedLayers.value.map((layer) => layer.id),
         selectedCategory.value.value
       )
+      selectedLayers.value = []
     }
 
     selectedCategory.value = null

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -559,11 +559,17 @@ const refreshLayerMappings = async () => {
 onMounted(() => {
   loadData()
 
-  // Listen for mappings changes from backend (with null safety)
+  // Listen for mappings changes from backend
   $revitMapperBinding?.on('mappingsChanged', (newMappings: CategoryMapping[]) => {
     mappings.value = newMappings
     // Also refresh layer mappings when backend notifies of changes
     refreshLayerMappings()
+  })
+
+  // Listen for document changes to refresh layer list
+  $baseBinding?.on('documentChanged', async () => {
+    await loadData()
+    selectedLayers.value = []
   })
 })
 </script>

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -169,7 +169,7 @@ const loadCategories = async () => {
   categoryOptions.value = categories
 }
 const refreshMappings = async () => {
-  const currentMappings = (await $revitMapperBinding?.getCurrentMappings()) || []
+  const currentMappings = (await $revitMapperBinding?.getCurrentObjectsMappings()) || []
   mappings.value = currentMappings
 }
 
@@ -179,17 +179,20 @@ const assignToCategory = async () => {
     return
   }
   const objectIds = selectionInfo.value.selectedObjectIds
-  await $revitMapperBinding?.assignToCategory(objectIds, selectedCategory.value.value)
+  await $revitMapperBinding?.assignObjectsToCategory(
+    objectIds,
+    selectedCategory.value.value
+  )
   await refreshMappings()
   selectedCategory.value = undefined
 }
 // === CATEGORY CLEARING ===
 const clearMapping = async (mapping: CategoryMapping) => {
-  await $revitMapperBinding?.clearCategoryAssignment(mapping.objectIds)
+  await $revitMapperBinding?.clearObjectsCategoryAssignment(mapping.objectIds)
   await refreshMappings()
 }
 const clearAllMappings = async () => {
-  await $revitMapperBinding?.clearAllCategoryAssignments()
+  await $revitMapperBinding?.clearAllObjectsCategoryAssignments()
   await refreshMappings()
 }
 


### PR DESCRIPTION
## Description
Category mapping system with Selection and Layer modes. Users can assign objects or layers to Revit categories with hierarchical resolution and conflict prevention (by **Clear And Switch**).

## User Value
Mapping via layers.

## Changes:
- Add mode toggle (Selection vs Layer) matching publish filter pattern
- Implement multi-select layer interface with hierarchy display
- Add mode switching with confirmation dialogs to prevent conflicts (# Clear And Switch)
- Create mappings tables showing current object/layer assignments  
- Layer highlighting that respects hierarchical resolution (objects that will be mapped are highlighted)

## Todo Before Merge:
- [ ] @oguzhankoral polish

## Screenshots:

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.