### PR TITLE
feat(dui): add select all mapped objects and auto-refresh improvements

### DIFF
--- a/lib/bindings/definitions/IRevitMapperBinding.ts
+++ b/lib/bindings/definitions/IRevitMapperBinding.ts
@@ -28,8 +28,8 @@ export interface IRevitMapperBinding extends IBinding<IMapperBindingEvents> {
 }
 
 export interface IMapperBindingEvents extends IBindingSharedEvents {
-  // Notify when mappings change
   mappingsChanged: (mappings: CategoryMapping[]) => void
+  layersChanged: (layers: LayerOption[]) => void
 }
 
 export interface Category {


### PR DESCRIPTION
## Description
Add "Select All" buttons to highlight all mapped objects at once and fix auto-refresh issues when user strings are manually modified in Rhino.

## User Value
Users can quickly see which objects have mappings (and invert selection to see unmapped objects) plus mappings automatically refresh when modified outside the UI.

## Changes:
- Add "Select All" buttons next to "Clear All" for both object and layer modes
- Fix mapping table not updating when user strings manually deleted in Rhino
- Remove redundant frontend document listeners (now handled by backend events)

## Validation of Changes

![select-all](https://github.com/user-attachments/assets/c76b7d35-19f8-451d-ad1b-914fe829bf35)

## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.