### PR TITLE
fix(mapper): pre-selected objects

### DIFF
--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -518,8 +518,10 @@ const refreshLayerMappings = async () => {
 }
 
 // === LIFECYCLE ===
-onMounted(() => {
-  loadData()
+onMounted(async () => {
+  await selectionStore.refreshSelectionFromHostApp()
+
+  await loadData()
 
   // Listen for mappings changes
   $revitMapperBinding?.on('mappingsChanged', (newMappings: CategoryMapping[]) => {


### PR DESCRIPTION
## Problem:
- Select object(s) in host app
- Go to `Assign Revit Categories`
- Selection mode doesn't recognise pre selected objects

## Fix:
Pre-selected object automatically recognised.

## Validation of Changes:
### Before
![before-fix](https://github.com/user-attachments/assets/01986e7d-b2f6-4b41-aa50-1b159be78359)

### After
![after-fix](https://github.com/user-attachments/assets/382469a4-6bae-40a4-8534-058166189490)
