### PR TITLE
fix(mapper): switches mapper terminology to category assignment

### DIFF
--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -500,7 +500,10 @@ const selectAllMappedLayers = async () => {
       await $baseBinding?.highlightObjects(uniqueObjectIds)
     }
   } catch (error) {
-    console.error('Failed to select all objects with categories assigned by layer:', error)
+    console.error(
+      'Failed to select all objects with categories assigned by layer:',
+      error
+    )
   }
 }
 


### PR DESCRIPTION
switches all user-facing text to remove the term "mapper/mapping"