### PR TITLE
Feat: disable update prompt in connectors

### DIFF
--- a/components/common/UpdateAlert.vue
+++ b/components/common/UpdateAlert.vue
@@ -1,6 +1,10 @@
 <template>
   <CommonAlert
-    v-if="!store.isConnectorUpToDate && !hasDismissedAlert"
+    v-if="
+      !store.isConnectorUpToDate &&
+      !hasDismissedAlert &&
+      !store.isUpdateNotificationDisabled
+    "
     v-tippy="
       'Version: ' + store.latestAvailableVersion?.Number + ', released ' + createdAgo
     "

--- a/lib/bindings/definitions/IConfigBinding.ts
+++ b/lib/bindings/definitions/IConfigBinding.ts
@@ -14,6 +14,7 @@ export const IConfigBindingKey = 'configBinding'
 export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
   getIsDevMode: () => Promise<boolean>
   getConfig: () => Promise<ConnectorConfig>
+  getGlobalConfig: () => Promise<GlobalConfig>
   updateConfig: (config: ConnectorConfig) => void
   setUserSelectedAccountId: (accountId: string) => void
   getUserSelectedAccountId: () => Promise<AccountsConfig>
@@ -23,6 +24,10 @@ export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
 }
 
 export interface IConfigBindingEvents extends IBindingSharedEvents {}
+
+export type GlobalConfig = {
+  isUpdateNotificationEnabled: boolean
+}
 
 export type ConnectorConfig = {
   darkTheme: boolean
@@ -44,6 +49,10 @@ export class MockedConfigBinding implements IConfigBinding {
 
   public async getConfig() {
     return await { darkTheme: false }
+  }
+
+  public async getGlobalConfig() {
+    return await { isUpdateNotificationEnabled: true }
   }
 
   public async updateConfig() {

--- a/lib/bindings/definitions/IConfigBinding.ts
+++ b/lib/bindings/definitions/IConfigBinding.ts
@@ -52,7 +52,7 @@ export class MockedConfigBinding implements IConfigBinding {
   }
 
   public async getGlobalConfig() {
-    return await { isUpdateNotificationEnabled: true }
+    return await { isUpdateNotificationDisabled: true }
   }
 
   public async updateConfig() {

--- a/lib/bindings/definitions/IConfigBinding.ts
+++ b/lib/bindings/definitions/IConfigBinding.ts
@@ -26,7 +26,7 @@ export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
 export interface IConfigBindingEvents extends IBindingSharedEvents {}
 
 export type GlobalConfig = {
-  isUpdateNotificationEnabled: boolean
+  isUpdateNotificationDisabled: boolean
 }
 
 export type ConnectorConfig = {

--- a/lib/common/generated/gql/graphql.ts
+++ b/lib/common/generated/gql/graphql.ts
@@ -134,6 +134,11 @@ export type AddDomainToWorkspaceInput = {
   workspaceId: Scalars['ID']['input'];
 };
 
+export type AdminAccessToWorkspaceFeatureInput = {
+  featureFlagName: WorkspaceFeatureFlagName;
+  workspaceId: Scalars['ID']['input'];
+};
+
 export type AdminInviteList = {
   __typename?: 'AdminInviteList';
   cursor?: Maybe<Scalars['String']['output']>;
@@ -143,7 +148,19 @@ export type AdminInviteList = {
 
 export type AdminMutations = {
   __typename?: 'AdminMutations';
+  giveAccessToWorkspaceFeature: Scalars['Boolean']['output'];
+  removeAccessToWorkspaceFeature: Scalars['Boolean']['output'];
   updateWorkspacePlan: Scalars['Boolean']['output'];
+};
+
+
+export type AdminMutationsGiveAccessToWorkspaceFeatureArgs = {
+  input: AdminAccessToWorkspaceFeatureInput;
+};
+
+
+export type AdminMutationsRemoveAccessToWorkspaceFeatureArgs = {
+  input: AdminAccessToWorkspaceFeatureInput;
 };
 
 
@@ -5244,8 +5261,14 @@ export type WorkspaceEmbedOptions = {
   hideSpeckleBranding: Scalars['Boolean']['output'];
 };
 
+export enum WorkspaceFeatureFlagName {
+  AccIntegration = 'accIntegration',
+  Dashboards = 'dashboards'
+}
+
 export enum WorkspaceFeatureName {
   AccIntegration = 'accIntegration',
+  Dashboards = 'dashboards',
   DomainBasedSecurityPolicies = 'domainBasedSecurityPolicies',
   ExclusiveMembership = 'exclusiveMembership',
   HideSpeckleBranding = 'hideSpeckleBranding',

--- a/lib/core/composables/updateConnector.ts
+++ b/lib/core/composables/updateConnector.ts
@@ -33,8 +33,6 @@ export function useUpdateConnector() {
 
   async function checkUpdate() {
     try {
-      console.log('check update')
-
       await getVersions()
     } catch (e) {
       console.error(e)

--- a/lib/core/composables/updateConnector.ts
+++ b/lib/core/composables/updateConnector.ts
@@ -33,6 +33,8 @@ export function useUpdateConnector() {
 
   async function checkUpdate() {
     try {
+      console.log('check update')
+
       await getVersions()
     } catch (e) {
       console.error(e)

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -56,8 +56,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const documentInfo = ref<DocumentInfo>()
   const documentModelStore = ref<DocumentModelStore>({ models: [] })
 
-  const isUpdateNotificationEnabled = ref(true)
-
   const availableViews = ref<string[]>() // TODO: later we can align views with -> const revitAvailableViews = ref<ISendFilterSelectItem[]>()
   const navisworksAvailableSavedSets = ref<ISendFilterSelectItem[]>()
 
@@ -535,15 +533,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const getHostAppVersion = async () =>
     (hostAppVersion.value = await app.$baseBinding.getSourceApplicationVersion())
 
-  const getIsUpdateNotificationEnabled = async () => {
-    const globalConfig = await app.$configBinding.getGlobalConfig()
-    isUpdateNotificationEnabled.value = globalConfig.isUpdateNotificationEnabled
-  }
-
   const getConnectorVersion = async () => {
     connectorVersion.value = await app.$baseBinding.getConnectorVersion()
+    const globalConfig = await app.$configBinding.getGlobalConfig()
     // Checks whether new version available for the connector or not and throws a toast notification if any.
-    if (app.$isRunningOnConnector && isUpdateNotificationEnabled.value) {
+    if (app.$isRunningOnConnector && globalConfig.isUpdateNotificationEnabled) {
       await checkUpdate()
     }
   }

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -56,6 +56,8 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const documentInfo = ref<DocumentInfo>()
   const documentModelStore = ref<DocumentModelStore>({ models: [] })
 
+  const isUpdateNotificationEnabled = ref(true)
+
   const availableViews = ref<string[]>() // TODO: later we can align views with -> const revitAvailableViews = ref<ISendFilterSelectItem[]>()
   const navisworksAvailableSavedSets = ref<ISendFilterSelectItem[]>()
 
@@ -533,10 +535,15 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
   const getHostAppVersion = async () =>
     (hostAppVersion.value = await app.$baseBinding.getSourceApplicationVersion())
 
+  const getIsUpdateNotificationEnabled = async () => {
+    const globalConfig = await app.$configBinding.getGlobalConfig()
+    isUpdateNotificationEnabled.value = globalConfig.isUpdateNotificationEnabled
+  }
+
   const getConnectorVersion = async () => {
     connectorVersion.value = await app.$baseBinding.getConnectorVersion()
     // Checks whether new version available for the connector or not and throws a toast notification if any.
-    if (app.$isRunningOnConnector) {
+    if (app.$isRunningOnConnector && isUpdateNotificationEnabled.value) {
       await checkUpdate()
     }
   }
@@ -701,6 +708,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await getHostAppName()
     await getHostAppVersion()
     await getConnectorVersion()
+    await getIsUpdateNotificationEnabled()
     await refreshDocumentInfo()
     await refreshDocumentModelStore()
     await refreshSendFilters()

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -549,8 +549,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
     // Checks whether new version available for the connector or not and throws a toast notification if any.
     if (app.$isRunningOnConnector && isUpdateNotificationEnabled) {
-      console.log('will check update')
-
       await checkUpdate()
     }
   }

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -702,7 +702,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await getHostAppName()
     await getHostAppVersion()
     await getConnectorVersion()
-    await getIsUpdateNotificationEnabled()
     await refreshDocumentInfo()
     await refreshDocumentModelStore()
     await refreshSendFilters()


### PR DESCRIPTION
For enterprise deployment, if IT sets the global config for disabling update promt, UI will rely on it. By default it is `true`.

PS: I check if binding has the relevant function or not for backward compatibility

Relavant connectors PR is in already https://github.com/specklesystems/speckle-sharp-connectors/pull/1041