### PR TITLE
feat(etabs): improve `MultiEnumControlRenderer` UX for analysis result export

### DIFF
--- a/components/form/json/MultiEnumControlRenderer.vue
+++ b/components/form/json/MultiEnumControlRenderer.vue
@@ -19,6 +19,7 @@
       button-style="tinted"
       :validate-on-value-update="validateOnValueUpdate"
       mount-menu-on-body
+      fixed-height
       @update:model-value="handleChange"
     >
       <template #nothing-selected>

--- a/components/form/json/MultiEnumControlRenderer.vue
+++ b/components/form/json/MultiEnumControlRenderer.vue
@@ -3,50 +3,58 @@
     <div class="text-foreground-2 text-body-2xs mb-1 pl-1">
       {{ control.label }}
     </div>
-    <FormSelectMulti
-      :model-value="modelValue"
-      :name="fieldName"
-      :rules="multiValidator"
-      :label="control.label"
-      :items="control.options"
-      clearable
-      :search="true"
-      :search-placeholder="'Search'"
-      :filter-predicate="searchFilterPredicate"
-      :help="control.description"
-      :allow-unset="false"
-      by="value"
-      button-style="tinted"
-      :validate-on-value-update="validateOnValueUpdate"
-      mount-menu-on-body
-      fixed-height
-      @update:model-value="handleChange"
-    >
-      <template #nothing-selected>
-        {{
-          appliedOptions['placeholder']
-            ? appliedOptions['placeholder']
-            : 'Select values'
-        }}
-      </template>
-      <template #something-selected="{ value }">
-        <div ref="elementToWatchForChanges" class="flex items-center space-x-0.5">
-          <div ref="itemContainer" class="flex flex-wrap overflow-hidden space-x-0.5">
-            <div v-for="(item, i) in value" :key="item.value" class="text-foreground">
-              {{ item.label + (i < value.length - 1 ? ', ' : '') }}
+    <div class="flex items-center space-x-2">
+      <FormSelectMulti
+        :model-value="modelValue"
+        :name="fieldName"
+        :rules="multiValidator"
+        :label="control.label"
+        :items="control.options"
+        class="flex-1"
+        clearable
+        :search="true"
+        :search-placeholder="'Search'"
+        :filter-predicate="searchFilterPredicate"
+        :help="control.description"
+        :allow-unset="false"
+        by="value"
+        button-style="tinted"
+        :validate-on-value-update="validateOnValueUpdate"
+        mount-menu-on-body
+        fixed-height
+        @update:model-value="handleChange"
+      >
+        <template #nothing-selected>
+          {{
+            appliedOptions['placeholder']
+              ? appliedOptions['placeholder']
+              : 'Select values'
+          }}
+        </template>
+        <template #something-selected="{ value }">
+          <div ref="elementToWatchForChanges" class="flex items-center space-x-0.5">
+            <div ref="itemContainer" class="flex flex-wrap overflow-hidden space-x-0.5">
+              <div v-for="(item, i) in value" :key="item.value" class="text-foreground">
+                {{ item.label + (i < value.length - 1 ? ', ' : '') }}
+              </div>
+            </div>
+            <div v-if="hiddenSelectedItemCount > 0" class="text-foreground-2 normal">
+              +{{ hiddenSelectedItemCount }}
             </div>
           </div>
-          <div v-if="hiddenSelectedItemCount > 0" class="text-foreground-2 normal">
-            +{{ hiddenSelectedItemCount }}
+        </template>
+        <template #option="{ item }">
+          <div class="flex items-center text-foreground-2 text-body-2xs">
+            <span class="truncate">{{ item.label }}</span>
           </div>
-        </div>
-      </template>
-      <template #option="{ item }">
-        <div class="flex items-center text-foreground-2 text-body-2xs">
-          <span class="truncate">{{ item.label }}</span>
-        </div>
-      </template>
-    </FormSelectMulti>
+        </template>
+      </FormSelectMulti>
+
+      <!-- Select all / Deselect all like Revit next to dropdown -->
+      <FormButton color="outline" size="sm" @click="toggleSelectAll">
+        {{ allSelected ? 'Deselect all' : 'Select all' }}
+      </FormButton>
+    </div>
   </div>
 </template>
 <script setup lang="ts">
@@ -109,4 +117,27 @@ const modelValue = computed(() => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
   return control.value.options.filter((o) => val?.includes(o.value))
 })
+
+/**
+ * Computed property to check if all available options are selected.
+ */
+const allSelected = computed(() => {
+  const currentSelection = modelValue.value || []
+  const allOptions = control.value.options || []
+  return currentSelection.length === allOptions.length && allOptions.length > 0
+})
+
+/**
+ * Toggle between selecting all categories and clearing all selections.
+ */
+const toggleSelectAll = () => {
+  if (allSelected.value) {
+    // deselect all -> pass empty array
+    handleChange([])
+  } else {
+    // select all available options
+    const allOptions = control.value.options || []
+    handleChange(allOptions)
+  }
+}
 </script>


### PR DESCRIPTION
## Description
Changes to the `MultiEnumControlRenderer` component used in ETABS analysis result exporter with two key improvements:

1. **Fixed scrolling issue** - added `fixed-height` property to allow scrolling when many categories are available
2. **Added select all/deselect all functionality** - added toggle button similar to Revit Categories component pattern

The button is positioned outside the dropdown and uses "Select all"/"Deselect all" (consistency with the Revit).

## User Value
Users can now efficiently scroll through large category lists and quickly select/deselect all categories at once when configuring ETABS analysis result exports. 

As requested: [Missing ETABS analysis Result Type ](https://speckle.community/t/missing-etabs-analysis-result-type/20336)

## Changes:
- Add `fixed-height` prop to FormSelectMulti for scrollable dropdown
- Add select all/deselect all toggle button positioned next to dropdown

## Screenshots & Validation of changes:

https://github.com/user-attachments/assets/ce2df7e8-4493-4090-99b6-998b973bb9a6


## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.