### PR TITLE
tbd/ fix(dui): includes server domain in mixpanel events

### DIFF
--- a/lib/core/composables/mixpanel.ts
+++ b/lib/core/composables/mixpanel.ts
@@ -62,9 +62,9 @@ export function useMixpanel() {
       }
       const hashedEmail =
         '@' + md5(lastEmail.value.toLowerCase() as string).toUpperCase()
-      const hashedServer = md5(
-        new URL(lastServer.value).hostname.toLowerCase() as string
-      ).toUpperCase()
+      const serverUrl = new URL(lastServer.value)
+      const serverHostname = serverUrl.hostname.toLowerCase()
+      const hashedServer = md5(serverHostname).toUpperCase()
 
       // Get os info from userAgent text
       // taken from original mixpanel implementation
@@ -84,6 +84,8 @@ export function useMixpanel() {
         distinct_id: hashedEmail,
         // eslint-disable-next-line camelcase
         server_id: hashedServer,
+        // eslint-disable-next-line camelcase
+        server_domain: serverHostname,
         token: mixpanelTokenId as string,
         type: isAction ? 'action' : undefined,
         hostApp: hostApp.hostAppName,


### PR DESCRIPTION
This adds the server domain info into the mixpanel events. 

Before:
<img width="1518" height="509" alt="image" src="https://github.com/user-attachments/assets/7840b54f-0f22-41fc-998c-07eb27e2a1c0" />

After:
<img width="1497" height="551" alt="image" src="https://github.com/user-attachments/assets/5af4835a-871b-491e-adc0-0c4ff5392c05" />

Note: There are some discussions about the naming convention, let's decide that before merge. 