### PR TITLE
fix: account existence check to also match by server url

### DIFF
--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -149,7 +149,31 @@ const accountExists =
   accountStore.isAccountExistsById(props.project.accountId) ||
   accountStore.isAccountExistsByServer(props.project.serverUrl)
 
+console.log('[ProjectModelGroup] Mounting for project:', {
+  projectId: props.project.projectId,
+  storedAccountId: props.project.accountId,
+  storedServerUrl: props.project.serverUrl,
+  accountExists,
+  existsById: accountStore.isAccountExistsById(props.project.accountId),
+  existsByServer: accountStore.isAccountExistsByServer(props.project.serverUrl),
+  availableAccounts: accountStore.accounts.map((a) => ({
+    id: a.accountInfo.id,
+    serverUrl: a.accountInfo.serverInfo.url
+  }))
+})
+
+console.log('[ProjectModelGroup] Mounting for project:', {
+  projectId: props.project.projectId,
+  serverUrl: props.project.serverUrl,
+  storedAccountId: props.project.accountId,
+  accountExists
+})
+
 if (!accountExists) {
+  console.log(
+    '[ProjectModelGroup] Account not found on this machine — marking project as inaccessible:',
+    props.project.projectId
+  )
   projectIsAccesible.value = false
 }
 
@@ -179,7 +203,13 @@ watch(projectDetails, (newValue) => {
   projectIsAccesible.value = newValue !== undefined
 })
 
-onProjectDetailsError(() => {
+onProjectDetailsError((err) => {
+  console.log('[ProjectModelGroup] projectDetailsQuery errored:', {
+    projectId: props.project.projectId,
+    error: err.message,
+    graphQLErrors: err.graphQLErrors,
+    networkError: err.networkError
+  })
   projectIsAccesible.value = false
 })
 

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -145,7 +145,9 @@ const projectNavigatorTippy = computed(() =>
 
 const clientId = projectAccount.value.accountInfo.id
 
-const accountExists = accountStore.isAccountExistsById(props.project.accountId)
+const accountExists =
+  accountStore.isAccountExistsById(props.project.accountId) ||
+  accountStore.isAccountExistsByServer(props.project.serverUrl)
 
 if (!accountExists) {
   projectIsAccesible.value = false


### PR DESCRIPTION
## Problem

Inaccessible project error showing up on a local server even though the account was valid and fully working.

Fixes [CNX-3291](https://linear.app/speckle/issue/CNX-3291/dui-error-sending-on-local-server).

## Reason
#103 introduced `accountExists` check that only matched by account ID. Previously (before #103) `accountWithFallback` handled this implicitly and always checked both ID **AND** server URL. Match by account ID only is too strict. 

## Changes
Fixed by adding `isAccountExistsByServer` as a fallback to the existence check, restoring the same behaviour that was there before.