### PR TITLE
fix: inaccessible project false positives for valid accounts

### DIFF
--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -145,7 +145,6 @@ const projectNavigatorTippy = computed(() =>
     : 'Open project in browser'
 )
 
-const clientId = projectAccount.value.accountInfo.id
 const normalizeUrl = (url: string) => url.replace(/\/$/, '').toLowerCase()
 
 // match by account ID first, then fall back to server URL
@@ -160,6 +159,9 @@ const accountExists = computed(() => {
   return byId || byServer
 })
 
+// reactive so it re-derives if accounts change after mount (e.g. user adds the missing account)
+const clientId = computed(() => projectAccount.value.accountInfo.id)
+
 const {
   result: projectDetailsResult,
   refetch: refetchProjectDetails,
@@ -168,12 +170,25 @@ const {
   projectDetailsQuery,
   () => ({ projectId: props.project.projectId }),
   () => ({
-    clientId,
+    clientId: clientId.value,
     debounce: 500,
     fetchPolicy: 'network-only',
     enabled: accountExists.value
   })
 )
+
+// re-run the query when the resolved account changes (account added) or
+// when accountExists flips back to true (account re-added after removal)
+watch([clientId, accountExists], ([, exists], [, prevExists]) => {
+  if (exists) {
+    if (!prevExists) {
+      // accountExists just recovered — reset accessible state so we don't
+      // show stale inaccessible UI while the query is in flight
+      projectIsAccesible.value = undefined
+    }
+    void refetchProjectDetails()
+  }
+})
 
 const removeProjectModels = async () => {
   await hostAppStore.removeProjectModels(props.project.projectId)
@@ -218,7 +233,7 @@ onProjectDetailsError((error) => {
     (e) => e.extensions?.code === 'SSO_SESSION_MISSING_OR_EXPIRED_ERROR'
   )
   if (isSsoError) {
-    // don't mark the project as permanently inaccessible
+    // sso expired - don't mark the project as permanently inaccessible
     return
   }
   console.warn('[ProjectModelGroup] inaccessible: project query errored', {
@@ -227,6 +242,18 @@ onProjectDetailsError((error) => {
     error: error.message
   })
   projectIsAccesible.value = false
+})
+
+// when the account's validity changes (e.g. SSO session deleted externally), refetch
+// so the query hits the server and picks up the new auth state
+const accountIsValid = computed(
+  () => accountStore.accounts.find((a) => a.accountInfo.id === clientId.value)?.isValid
+)
+
+watch(accountIsValid, (isValid, wasValid) => {
+  if (wasValid !== undefined && isValid !== wasValid) {
+    void refetchProjectDetails()
+  }
 })
 
 const canLoad = computed(() => !!projectDetails.value?.permissions.canLoad.authorized)
@@ -261,13 +288,13 @@ const isWorkspaceReadOnly = computed(() => {
 const { onResult: userProjectsUpdated } = useSubscription(
   userProjectsUpdatedSubscription,
   () => ({}),
-  () => ({ clientId, enabled: accountExists.value })
+  () => ({ clientId: clientId.value, enabled: accountExists.value })
 )
 
 const { onResult: projectUpdated } = useSubscription(
   projectUpdatedSubscription,
   () => ({ projectId: props.project.projectId }),
-  () => ({ clientId, enabled: accountExists.value })
+  () => ({ clientId: clientId.value, enabled: accountExists.value })
 )
 
 // to catch changes on visibility of project
@@ -286,14 +313,14 @@ userProjectsUpdated((res) => {
 })
 
 const projectUrl = computed(() => {
-  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId)
+  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId.value)
   return `${acc?.accountInfo.serverInfo.url as string}/projects/${
     props.project.projectId
   }`
 })
 
 const workspaceUrl = computed(() => {
-  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId)
+  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId.value)
   return `${acc?.accountInfo.serverInfo.url as string}/workspaces/${
     projectDetails.value?.workspace?.slug
   }`
@@ -303,7 +330,7 @@ const workspaceUrl = computed(() => {
 const { onResult } = useSubscription(
   versionCreatedSubscription,
   () => ({ projectId: props.project.projectId }),
-  () => ({ clientId, enabled: accountExists.value })
+  () => ({ clientId: clientId.value, enabled: accountExists.value })
 )
 
 onResult((res) => {

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -146,11 +146,17 @@ const projectNavigatorTippy = computed(() =>
 )
 
 const clientId = projectAccount.value.accountInfo.id
+const normalizeUrl = (url: string) => url.replace(/\/$/, '').toLowerCase()
 
 // match by account ID first, then fall back to server URL
+// normalized to avoid trailing-slash / casing mismatches (can that even be a thing??)
 const accountExists = computed(() => {
   const byId = accountStore.isAccountExistsById(props.project.accountId)
-  const byServer = accountStore.isAccountExistsByServer(props.project.serverUrl)
+  const byServer = accountStore.accounts.some(
+    (acc) =>
+      normalizeUrl(acc.accountInfo.serverInfo.url) ===
+      normalizeUrl(props.project.serverUrl)
+  )
   console.log('[ProjectModelGroup] accountExists check', {
     projectId: props.project.projectId,
     accountId: props.project.accountId,
@@ -163,12 +169,6 @@ const accountExists = computed(() => {
     }))
   })
   return byId || byServer
-})
-
-watchEffect(() => {
-  if (!accountExists.value) {
-    projectIsAccesible.value = false
-  }
 })
 
 const {
@@ -194,22 +194,20 @@ const removeProjectModels = async () => {
 const projectDetails = computed(() => projectDetailsResult.value?.project)
 
 watch(
-  projectDetails,
-  (newValue) => {
-    console.log('[ProjectModelGroup] projectDetails changed', {
+  [projectDetails, accountExists],
+  ([details, exists]) => {
+    console.log('[ProjectModelGroup] projectDetails/accountExists changed', {
       projectId: props.project.projectId,
-      newValue,
-      settingAccessibleTo:
-        newValue === null
-          ? false
-          : newValue !== undefined
-          ? true
-          : 'no change (loading)'
+      details,
+      exists
     })
-    if (newValue === null) {
+    if (!exists) {
+      // account not present on this machine at all
+      projectIsAccesible.value = false
+    } else if (details === null) {
       // query resolved but project is missing or user has no permissions
       projectIsAccesible.value = false
-    } else if (newValue !== undefined) {
+    } else if (details !== undefined) {
       // query returned real data — project is accessible
       projectIsAccesible.value = true
     }

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -229,13 +229,6 @@ watch(
 )
 
 onProjectDetailsError((error) => {
-  const isSsoError = error.graphQLErrors?.some(
-    (e) => e.extensions?.code === 'SSO_SESSION_MISSING_OR_EXPIRED_ERROR'
-  )
-  if (isSsoError) {
-    // sso expired - don't mark the project as permanently inaccessible
-    return
-  }
   console.warn('[ProjectModelGroup] inaccessible: project query errored', {
     projectId: props.project.projectId,
     accountId: props.project.accountId,

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -83,9 +83,18 @@
       @dismiss="askDismissProjectQuestionDialog = true"
     >
       <template #title>
-        Whoops - project
-        <code>{{ project.projectId }}</code>
-        is inaccessible.
+        <span v-if="inaccessibleReason === 'no-account'">
+          No account found for
+          <code>{{ project.serverUrl }}</code>
+        </span>
+        <span v-else-if="inaccessibleReason === 'no-permission'">
+          You don't have access to this project on
+          <code>{{ project.serverUrl }}</code>
+        </span>
+        <span v-else>
+          Could not reach
+          <code>{{ project.serverUrl }}</code>
+        </span>
       </template>
     </CommonAlert>
     <CommonDialog v-model:open="askDismissProjectQuestionDialog" fullscreen="none">
@@ -133,6 +142,9 @@ const showModels = ref(true)
 const askDismissProjectQuestionDialog = ref(false)
 const writeAccessRequested = ref(false)
 const projectIsAccesible = ref<boolean | undefined>(undefined)
+const inaccessibleReason = ref<'no-account' | 'no-permission' | 'error' | undefined>(
+  undefined
+)
 
 const projectAccount = computed(() =>
   accountStore.accountWithFallback(props.project.accountId, props.project.serverUrl)
@@ -211,6 +223,7 @@ watch(
           serverUrl: a.accountInfo.serverInfo.url
         }))
       })
+      inaccessibleReason.value = 'no-account'
       projectIsAccesible.value = false
     } else if (details === null) {
       // query resolved but project is missing or user has no permissions
@@ -218,9 +231,11 @@ watch(
         projectId: props.project.projectId,
         accountId: props.project.accountId
       })
+      inaccessibleReason.value = 'no-permission'
       projectIsAccesible.value = false
     } else if (details !== undefined) {
       // query returned real data — project is accessible
+      inaccessibleReason.value = undefined
       projectIsAccesible.value = true
     }
     // undefined means the query is still loading; don't update state yet
@@ -234,6 +249,7 @@ onProjectDetailsError((error) => {
     accountId: props.project.accountId,
     error: error.message
   })
+  inaccessibleReason.value = 'error'
   projectIsAccesible.value = false
 })
 

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -214,6 +214,13 @@ watch(
 )
 
 onProjectDetailsError((error) => {
+  const isSsoError = error.graphQLErrors?.some(
+    (e) => e.extensions?.code === 'SSO_SESSION_MISSING_OR_EXPIRED_ERROR'
+  )
+  if (isSsoError) {
+    // don't mark the project as permanently inaccessible
+    return
+  }
   console.warn('[ProjectModelGroup] inaccessible: project query errored', {
     projectId: props.project.projectId,
     accountId: props.project.accountId,

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -145,11 +145,18 @@ const projectNavigatorTippy = computed(() =>
 
 const clientId = projectAccount.value.accountInfo.id
 
-const accountExists = accountStore.isAccountExistsById(props.project.accountId)
+// match by account ID first, then fall back to server URL
+const accountExists = computed(
+  () =>
+    accountStore.isAccountExistsById(props.project.accountId) ||
+    accountStore.isAccountExistsByServer(props.project.serverUrl)
+)
 
-if (!accountExists) {
-  projectIsAccesible.value = false
-}
+watchEffect(() => {
+  if (!accountExists.value) {
+    projectIsAccesible.value = false
+  }
+})
 
 const {
   result: projectDetailsResult,
@@ -162,7 +169,7 @@ const {
     clientId,
     debounce: 500,
     fetchPolicy: 'network-only',
-    enabled: accountExists
+    enabled: accountExists.value
   })
 )
 
@@ -173,9 +180,20 @@ const removeProjectModels = async () => {
 
 const projectDetails = computed(() => projectDetailsResult.value?.project)
 
-watch(projectDetails, (newValue) => {
-  projectIsAccesible.value = newValue !== undefined
-})
+watch(
+  projectDetails,
+  (newValue) => {
+    if (newValue === null) {
+      // query resolved but project is missing or user has no permissions
+      projectIsAccesible.value = false
+    } else if (newValue !== undefined) {
+      // query returned real data — project is accessible
+      projectIsAccesible.value = true
+    }
+    // undefined means the query is still loading; don't update state yet
+  },
+  { immediate: true }
+)
 
 onProjectDetailsError(() => {
   projectIsAccesible.value = false
@@ -213,13 +231,13 @@ const isWorkspaceReadOnly = computed(() => {
 const { onResult: userProjectsUpdated } = useSubscription(
   userProjectsUpdatedSubscription,
   () => ({}),
-  () => ({ clientId, enabled: accountExists })
+  () => ({ clientId, enabled: accountExists.value })
 )
 
 const { onResult: projectUpdated } = useSubscription(
   projectUpdatedSubscription,
   () => ({ projectId: props.project.projectId }),
-  () => ({ clientId, enabled: accountExists })
+  () => ({ clientId, enabled: accountExists.value })
 )
 
 // to catch changes on visibility of project
@@ -255,7 +273,7 @@ const workspaceUrl = computed(() => {
 const { onResult } = useSubscription(
   versionCreatedSubscription,
   () => ({ projectId: props.project.projectId }),
-  () => ({ clientId, enabled: accountExists })
+  () => ({ clientId, enabled: accountExists.value })
 )
 
 onResult((res) => {

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -84,20 +84,24 @@
     >
       <template #title>
         <span v-if="inaccessibleReason === 'no-account'">
+          <!-- no local account matches this project's server — query was never attempted -->
           No account found for
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else-if="inaccessibleReason === 'no-permission'">
-          <!-- user lost access (removed from team / visibility changed) -->
+          <!-- project query resolved but returned null — project is private, deleted,
+               or this account has no visibility of it at the project level.
+               note: model card level permission errors (e.g. role changes) surface separately on the card itself -->
           Project
           <code>{{ project.projectId }}</code>
-          not found you no longer have access on
+          not found or inaccessible on
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else>
-          <!-- network error, expired token, or server rejected the request -->
-          Failed to load project from
+          <!-- query failed before resolving — network error or token expired/invalidated -->
+          Could not connect to
           <code>{{ project.serverUrl }}</code>
+          — try re-adding your account
         </span>
       </template>
     </CommonAlert>

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -148,11 +148,22 @@ const projectNavigatorTippy = computed(() =>
 const clientId = projectAccount.value.accountInfo.id
 
 // match by account ID first, then fall back to server URL
-const accountExists = computed(
-  () =>
-    accountStore.isAccountExistsById(props.project.accountId) ||
-    accountStore.isAccountExistsByServer(props.project.serverUrl)
-)
+const accountExists = computed(() => {
+  const byId = accountStore.isAccountExistsById(props.project.accountId)
+  const byServer = accountStore.isAccountExistsByServer(props.project.serverUrl)
+  console.log('[ProjectModelGroup] accountExists check', {
+    projectId: props.project.projectId,
+    accountId: props.project.accountId,
+    serverUrl: props.project.serverUrl,
+    existsById: byId,
+    existsByServer: byServer,
+    accounts: accountStore.accounts.map((a) => ({
+      id: a.accountInfo.id,
+      serverUrl: a.accountInfo.serverInfo.url
+    }))
+  })
+  return byId || byServer
+})
 
 watchEffect(() => {
   if (!accountExists.value) {
@@ -185,6 +196,16 @@ const projectDetails = computed(() => projectDetailsResult.value?.project)
 watch(
   projectDetails,
   (newValue) => {
+    console.log('[ProjectModelGroup] projectDetails changed', {
+      projectId: props.project.projectId,
+      newValue,
+      settingAccessibleTo:
+        newValue === null
+          ? false
+          : newValue !== undefined
+          ? true
+          : 'no change (loading)'
+    })
     if (newValue === null) {
       // query resolved but project is missing or user has no permissions
       projectIsAccesible.value = false

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -88,10 +88,10 @@
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else-if="inaccessibleReason === 'no-permission'">
-          <!-- project was deleted, or user lost access (removed from team / visibility changed) -->
+          <!-- user lost access (removed from team / visibility changed) -->
           Project
           <code>{{ project.projectId }}</code>
-          not found or inaccessible on
+          not found you no longer have access on
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else>

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -92,13 +92,15 @@
       <template #header>Remove Project</template>
       <div class="text-xs mb-4">Do you want to remove the project from this file?</div>
       <div class="flex justify-between center py-2 space-x-3">
-        <FormButton size="sm" full-width @click="removeProjectModels">Yes</FormButton>
+        <FormButton size="sm" full-width @click="removeProjectModels">
+          Remove
+        </FormButton>
         <FormButton
           size="sm"
           full-width
           @click="askDismissProjectQuestionDialog = false"
         >
-          Hide error
+          Cancel
         </FormButton>
       </div>
     </CommonDialog>

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -88,20 +88,14 @@
           No account found for
           <code>{{ project.serverUrl }}</code>
         </span>
-        <span v-else-if="inaccessibleReason === 'no-permission'">
-          <!-- project query resolved but returned null — project is private, deleted,
-               or this account has no visibility of it at the project level.
-               note: model card level permission errors (e.g. role changes) surface separately on the card itself -->
+        <span v-else>
+          <!-- project query threw — server will throw for any reason the account can't see
+               the project (deleted, private, auth failure, stale token). model card level
+               permission errors e.g. role changes surface separately on the card itself -->
           Project
           <code>{{ project.projectId }}</code>
-          not found or inaccessible on
+          is not accessible on
           <code>{{ project.serverUrl }}</code>
-        </span>
-        <span v-else>
-          <!-- query failed before resolving — network error or token expired/invalidated -->
-          Could not connect to
-          <code>{{ project.serverUrl }}</code>
-          — try re-adding your account
         </span>
       </template>
     </CommonAlert>
@@ -150,9 +144,7 @@ const showModels = ref(true)
 const askDismissProjectQuestionDialog = ref(false)
 const writeAccessRequested = ref(false)
 const projectIsAccesible = ref<boolean | undefined>(undefined)
-const inaccessibleReason = ref<'no-account' | 'no-permission' | 'error' | undefined>(
-  undefined
-)
+const inaccessibleReason = ref<'no-account' | 'error' | undefined>(undefined)
 
 const projectAccount = computed(() =>
   accountStore.accountWithFallback(props.project.accountId, props.project.serverUrl)
@@ -233,14 +225,6 @@ watch(
       })
       inaccessibleReason.value = 'no-account'
       projectIsAccesible.value = false
-    } else if (details === null) {
-      // query resolved but project is missing or user has no permissions
-      console.warn('[ProjectModelGroup] inaccessible: project query returned null', {
-        projectId: props.project.projectId,
-        accountId: props.project.accountId
-      })
-      inaccessibleReason.value = 'no-permission'
-      projectIsAccesible.value = false
     } else if (details !== undefined) {
       // query returned real data — project is accessible
       inaccessibleReason.value = undefined
@@ -252,6 +236,8 @@ watch(
 )
 
 onProjectDetailsError((error) => {
+  // the project query throws for any reason the account can't see the project —
+  // deleted, private, auth failure, network error. all cases show the same message.
   console.warn('[ProjectModelGroup] inaccessible: project query errored', {
     projectId: props.project.projectId,
     accountId: props.project.accountId,

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -157,17 +157,6 @@ const accountExists = computed(() => {
       normalizeUrl(acc.accountInfo.serverInfo.url) ===
       normalizeUrl(props.project.serverUrl)
   )
-  console.log('[ProjectModelGroup] accountExists check', {
-    projectId: props.project.projectId,
-    accountId: props.project.accountId,
-    serverUrl: props.project.serverUrl,
-    existsById: byId,
-    existsByServer: byServer,
-    accounts: accountStore.accounts.map((a) => ({
-      id: a.accountInfo.id,
-      serverUrl: a.accountInfo.serverInfo.url
-    }))
-  })
   return byId || byServer
 })
 
@@ -196,16 +185,24 @@ const projectDetails = computed(() => projectDetailsResult.value?.project)
 watch(
   [projectDetails, accountExists],
   ([details, exists]) => {
-    console.log('[ProjectModelGroup] projectDetails/accountExists changed', {
-      projectId: props.project.projectId,
-      details,
-      exists
-    })
     if (!exists) {
       // account not present on this machine at all
+      console.warn('[ProjectModelGroup] inaccessible: no matching account', {
+        projectId: props.project.projectId,
+        storedAccountId: props.project.accountId,
+        storedServerUrl: props.project.serverUrl,
+        localAccounts: accountStore.accounts.map((a) => ({
+          id: a.accountInfo.id,
+          serverUrl: a.accountInfo.serverInfo.url
+        }))
+      })
       projectIsAccesible.value = false
     } else if (details === null) {
       // query resolved but project is missing or user has no permissions
+      console.warn('[ProjectModelGroup] inaccessible: project query returned null', {
+        projectId: props.project.projectId,
+        accountId: props.project.accountId
+      })
       projectIsAccesible.value = false
     } else if (details !== undefined) {
       // query returned real data — project is accessible
@@ -216,7 +213,12 @@ watch(
   { immediate: true }
 )
 
-onProjectDetailsError(() => {
+onProjectDetailsError((error) => {
+  console.warn('[ProjectModelGroup] inaccessible: project query errored', {
+    projectId: props.project.projectId,
+    accountId: props.project.accountId,
+    error: error.message
+  })
   projectIsAccesible.value = false
 })
 

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -88,11 +88,15 @@
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else-if="inaccessibleReason === 'no-permission'">
-          You don't have access to this project on
+          <!-- project was deleted, or user lost access (removed from team / visibility changed) -->
+          Project
+          <code>{{ project.projectId }}</code>
+          not found or inaccessible on
           <code>{{ project.serverUrl }}</code>
         </span>
         <span v-else>
-          Could not reach
+          <!-- network error, expired token, or server rejected the request -->
+          Failed to load project from
           <code>{{ project.serverUrl }}</code>
         </span>
       </template>

--- a/components/model/Receiver.vue
+++ b/components/model/Receiver.vue
@@ -30,16 +30,6 @@
         <span class="truncate">{{ createdAgo }}</span>
       </FormButton>
     </div>
-    <!-- <div
-        class="min-w-0 truncate text-foreground-2 -mt-1"
-        :title="
-          versionDetailsResult?.project.model.version.message || 'No message provided'
-        "
-      >
-        <span class="truncate max-[275px]:truncate-no select-none text-xs">
-          {{ createdAgo }}
-        </span>
-      </div> -->
 
     <CommonDialog
       v-model:open="openVersionsDialog"
@@ -271,6 +261,8 @@ const errorNotification = computed(() => {
   return notification
 })
 
+const clientId = computed(() => projectAccount.value?.accountInfo.id)
+
 const { result: versionDetailsResult, refetch } = useQuery(
   versionDetailsQuery,
   () => ({
@@ -279,7 +271,8 @@ const { result: versionDetailsResult, refetch } = useQuery(
     versionId: props.modelCard.selectedVersionId
   }),
   () => ({
-    clientId: projectAccount.value.accountInfo.id
+    clientId: clientId.value,
+    enabled: !!clientId.value
   })
 )
 

--- a/components/model/Receiver.vue
+++ b/components/model/Receiver.vue
@@ -30,7 +30,16 @@
         <span class="truncate">{{ createdAgo }}</span>
       </FormButton>
     </div>
-
+    <!-- <div
+        class="min-w-0 truncate text-foreground-2 -mt-1"
+        :title="
+          versionDetailsResult?.project.model.version.message || 'No message provided'
+        "
+      >
+        <span class="truncate max-[275px]:truncate-no select-none text-xs">
+          {{ createdAgo }}
+        </span>
+      </div> -->
     <CommonDialog
       v-model:open="openVersionsDialog"
       fullscreen="none"

--- a/components/model/Sender.vue
+++ b/components/model/Sender.vue
@@ -401,6 +401,7 @@ const latestVersionNotification = computed(() => {
   notification.cta = {
     name: 'View',
     tooltipText: 'Check your model in the browser!',
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     action: () => cardBase.value?.viewModel()
   }
   return notification

--- a/components/model/Sender.vue
+++ b/components/model/Sender.vue
@@ -134,6 +134,7 @@ import {
   useSubscription
 } from '@vue/apollo-composable'
 import { useAccountStore } from '~/store/accounts'
+import type { ApolloClient } from '@apollo/client/core'
 import { setVersionMessageMutation } from '~/lib/graphql/mutationsAndQueries'
 import { workspacePlanUsageUpdatedSubscription } from '~/lib/workspaces/graphql/subscriptions'
 import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
@@ -253,7 +254,9 @@ const setVersionMessage = async (message: string) => {
   })
 
   isUpdatingVersionMessage.value = true
-  const { mutate } = provideApolloClient(projectAccount.value.client)(() =>
+  const client = projectAccount.value?.client as ApolloClient<unknown> | undefined
+  if (!client) return
+  const { mutate } = provideApolloClient(client)(() =>
     useMutation(setVersionMessageMutation)
   )
 

--- a/components/model/Sender.vue
+++ b/components/model/Sender.vue
@@ -133,7 +133,7 @@ import {
   useMutation,
   useSubscription
 } from '@vue/apollo-composable'
-import { useAccountStore, type DUIAccount } from '~/store/accounts'
+import { useAccountStore } from '~/store/accounts'
 import { setVersionMessageMutation } from '~/lib/graphql/mutationsAndQueries'
 import { workspacePlanUsageUpdatedSubscription } from '~/lib/workspaces/graphql/subscriptions'
 import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
@@ -152,10 +152,10 @@ const props = defineProps<{
   canEdit: boolean
 }>()
 
-const account = accountStore.accounts.find(
-  (acc) => acc.accountInfo.id === props.project.accountId
-) as DUIAccount
-const clientId = account.accountInfo.id
+const projectAccount = computed(() =>
+  accountStore.accountWithFallback(props.project.accountId, props.project.serverUrl)
+)
+const clientId = computed(() => projectAccount.value?.accountInfo.id)
 
 const openFilterDialog = ref(false)
 app.$baseBinding?.on('documentChanged', () => {
@@ -189,7 +189,7 @@ const { onResult: onWorkspacePlanUsageUpdated } = useSubscription(
       workspaceId: props.modelCard.workspaceId as string
     }
   }),
-  () => ({ clientId })
+  () => ({ clientId: clientId.value })
 )
 
 onWorkspacePlanUsageUpdated(() => {
@@ -253,7 +253,7 @@ const setVersionMessage = async (message: string) => {
   })
 
   isUpdatingVersionMessage.value = true
-  const { mutate } = provideApolloClient(account.client)(() =>
+  const { mutate } = provideApolloClient(projectAccount.value.client)(() =>
     useMutation(setVersionMessageMutation)
   )
 
@@ -401,7 +401,6 @@ const latestVersionNotification = computed(() => {
   notification.cta = {
     name: 'View',
     tooltipText: 'Check your model in the browser!',
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-call, @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-member-access
     action: () => cardBase.value?.viewModel()
   }
   return notification

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -218,6 +218,9 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     )
     if (modelsToRemove.length !== 0) {
       await app.$baseBinding.removeModels(modelsToRemove)
+      documentModelStore.value.models = documentModelStore.value.models.filter(
+        (item) => item.projectId !== projectId
+      )
     }
   }
 


### PR DESCRIPTION
## Overview
The inaccessible project error UI was dead code from the start — the condition rendering it was a logical contradiction that always evaluated to `false` (state before #103):

```vue
v-if="projectIsAccesible && !projectIsAccesible"
```

So regardless of what happened, the error block never rendered. Users opening a shared file where the account didn't exist would just see an empty orphaned collapsible with no way to remove it.

The false positives reported during testing changes from #103 resolved within this PR. This should strictly be an improvement.

## Changes
- `ProjectModelGroup.vue`
   - `accountExists` was only checking by account ID — changed to also fall back to server URL match, normalized for trailing slashes and casing, consistent with how `accountWithFallback` worked
   - `accountExists` was a one-time snapshot at setup — made it a `computed` so it stays reactive if accounts change after mount.
   - `clientId` was a plain string snapshotted at setup — made it a `computed` so it re-derives when accounts change. Added a `watch([clientId, accountExists])` to refetch when the resolved account changes or `accountExists` recovers, so adding a missing account auto-recovers the card without a manual refresh.
   - Added `accountIsValid` computed to watch the account's validity flag. When it changes, the query refetches immediately rather than waiting for a manual refresh.

- `hostApp.ts`
   - `removeProjectModels` was calling `removeModels` on the binding but never updating the local store, so the UI wouldn't react until a manual refresh. Fixed by filtering `documentModelStore` after the binding call, consistent with how `removeAccountModels` already works.

## Testing & Validation of Changes
All possible failure paths (in my head) described below.

### Orphaned blank state on missing account (Sender/Receiver) ✅
- Reproduced on the original file that triggered the first ticket ([CNX-3262](https://linear.app/speckle/issue/CNX-3262/project-collapsible-shows-up-when-user-dont-have-any-access-no-way-to))
- `Sender.vue` was doing a raw `accounts.find()` with no fallback and immediately reading `.accountInfo` on the result — crashes with `TypeError: Cannot read properties of undefined (reading 'accountInfo')` when the account doesn't exist on the machine
- `Receiver.vue` had the same `clientId` snapshot problem
- Fixed both to use `accountWithFallback` + computed `clientId`

https://github.com/user-attachments/assets/90050d03-ea4a-45a4-8154-576f0a5501f6

### Account not found ✅
- Two model cards — one associated with app.speckle account, the other with latest.speckle account
- latest.speckle account removed before opening Rhino model
- Model card associated with latest.speckle account correctly flagged with "No account found for `https://latest.speckle.systems`"
- Added account back under Manage Accounts
- Model card automatically recovers and error disappears

https://github.com/user-attachments/assets/d2d5d413-838a-407b-b7ff-7fa9bc868007

### Project inaccessible ✅
- Validated by deleting a project — model card correctly shows "Project `abc123` is not accessible on `https://app.speckle.systems`"
- Video also shows Dismiss and Remove doing exactly that. Previously this did nothing
- Same path covers: project made private, account has no visibility, auth failure, stale token — the server throws for all of these so they all route to the same message

https://github.com/user-attachments/assets/60eb9601-029f-4459-a59f-099875cb198d

### Expired SSO ✅
- When SSO session expires, the associated model card gets removed upstream by the accounts store
- Model card disappears rather than showing an error — this is existing behaviour outside the scope of this component
- No false positive inaccessible banner shown

### 403 Error ⚠️ !!
- Reproduced by Bilal — model card correctly showed "Project `abc123` is not accessible on `https://latest.speckle.systems`"
- Root cause: not sure yet

### Permission changes (role downgrade / removed from project) ✅
- Project query still resolves when a member is removed or downgraded — permission errors surface at the model card level, not the project level
- No inaccessible banner shown — error appears inline on the affected model card as expected

https://github.com/user-attachments/assets/32a0d3c5-e57a-46f4-aa95-53e8e962eb50

### Removed from workspace ✅
- Same behaviour as above — project remains visible, error surfaces on the model card
- Applies to deleted models too 

https://github.com/user-attachments/assets/91f33c29-6a6c-4a01-b48b-bcc3bc09d0b8