### PR TITLE
feat(dui): adds tooltip to settings

### DIFF
--- a/components/form/json/BooleanControlRenderer.vue
+++ b/components/form/json/BooleanControlRenderer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="text-foreground-2 text-body-2xs mb-1 pl-1">{{ control.label }}</div>
+    <FormJsonControlLabel :label="control.label" :description="control.description" />
     <FormSwitch
       :name="fieldName"
       :disabled="!control.enabled"

--- a/components/form/json/ControlLabel.vue
+++ b/components/form/json/ControlLabel.vue
@@ -1,0 +1,25 @@
+<template>
+  <!--
+    Shared label for JsonForms control renderers in the connector settings panel.
+
+    Surfaces `description` as a tooltip on hover via `v-tippy`. When the
+    description is empty, missing, or whitespace-only, no tooltip is rendered —
+    so settings without a description defined render with no visual change.
+  -->
+  <div v-tippy="tooltip" class="text-foreground-2 text-body-2xs mb-1 pl-1 inline-block">
+    {{ label }}
+  </div>
+</template>
+
+<script setup lang="ts">
+const props = defineProps<{
+  label: string
+  description?: string
+}>()
+
+const tooltip = computed<string | undefined>(() => {
+  if (!props.description) return undefined
+  const trimmed = props.description.trim()
+  return trimmed.length > 0 ? trimmed : undefined
+})
+</script>

--- a/components/form/json/EnumControlRenderer.vue
+++ b/components/form/json/EnumControlRenderer.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <div class="text-foreground-2 text-body-2xs mb-1 pl-1">{{ control.label }}</div>
+    <FormJsonControlLabel :label="control.label" :description="control.description" />
     <FormSelectBase
       :model-value="modelValue"
       :name="fieldName"
@@ -8,7 +8,6 @@
       :label="control.label"
       :items="control.options"
       :multiple="multiple"
-      :help="control.description"
       :allow-unset="false"
       by="value"
       button-style="tinted"

--- a/components/form/json/MultiEnumControlRenderer.vue
+++ b/components/form/json/MultiEnumControlRenderer.vue
@@ -18,7 +18,6 @@
         :search="true"
         :search-placeholder="'Search'"
         :filter-predicate="searchFilterPredicate"
-        :help="control.description"
         :allow-unset="false"
         by="value"
         button-style="tinted"

--- a/lib/common/helpers/array.ts
+++ b/lib/common/helpers/array.ts
@@ -1,0 +1,10 @@
+/**
+ * Shallow equality check for arrays of primitives. Treats two undefineds as equal
+ * and any undefined-vs-defined pair as unequal.
+ */
+export const arraysEqual = <T>(a: T[] | undefined, b: T[] | undefined): boolean => {
+  if (a === b) return true
+  if (!a || !b) return false
+  if (a.length !== b.length) return false
+  return a.every((v, i) => v === b[i])
+}

--- a/lib/models/card/setting.ts
+++ b/lib/models/card/setting.ts
@@ -6,6 +6,7 @@ export interface CardSetting extends IDiscriminatedObject {
   title: string
   value: CardSettingValue
   enum?: string[]
+  description?: string
 }
 
 export type CardSettingValue = string | number | boolean

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -824,19 +824,33 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     modelCards.forEach(async (modelCard) => {
       const idsToUpgrade = [] as string[]
       const idsToDrop = [] as string[]
+      let structuralFieldsChanged = false
 
       settingIds?.forEach((id) => {
         const existingSetting = modelCard.settings?.find((s) => s.id === id)
+        const defaultSetting = settings.find((s) => s.id === id)
 
         if (!existingSetting) {
           // If the setting does not exist, it's a new one to upgrade
           idsToUpgrade.push(id)
-        } else if (existingSetting.type === 'string' && existingSetting.enum) {
-          // Check if existing setting's enum needs upgrading
-          const currentEnum = sendSettings.value?.find((s) => s.id === id)?.enum
-          if (currentEnum && existingSetting.enum.length !== currentEnum.length) {
-            idsToUpgrade.push(id)
-          }
+          return
+        }
+
+        if (!defaultSetting) return
+
+        // Refresh title, description etc fields from the connector default while preserving
+        // the user's chosen value.
+        if (
+          existingSetting.title !== defaultSetting.title ||
+          existingSetting.description !== defaultSetting.description ||
+          existingSetting.type !== defaultSetting.type ||
+          !arraysEqual(existingSetting.enum, defaultSetting.enum)
+        ) {
+          existingSetting.title = defaultSetting.title
+          existingSetting.description = defaultSetting.description
+          existingSetting.type = defaultSetting.type
+          existingSetting.enum = defaultSetting.enum
+          structuralFieldsChanged = true
         }
       })
 
@@ -847,7 +861,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         }
       })
 
-      if (idsToUpgrade.length !== 0 || idsToDrop.length !== 0) {
+      if (
+        idsToUpgrade.length !== 0 ||
+        idsToDrop.length !== 0 ||
+        structuralFieldsChanged
+      ) {
         // Prepare new settings by filtering the old ones and adding upgraded ones
         const newSettings = modelCard.settings?.filter(
           (setting) => !idsToDrop.includes(setting.id)
@@ -866,6 +884,13 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         })
       }
     })
+  }
+
+  const arraysEqual = (a: string[] | undefined, b: string[] | undefined): boolean => {
+    if (a === b) return true
+    if (!a || !b) return false
+    if (a.length !== b.length) return false
+    return a.every((v, i) => v === b[i])
   }
 
   app.$baseBinding?.on(

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -33,6 +33,7 @@ import { createVersionMutation } from '~/lib/graphql/mutationsAndQueries'
 import type { BaseBridge } from '~/lib/bridge/base'
 import { useModelIngestion } from '~/lib/ingestion/composables/useModelIngestion'
 import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
+import { arraysEqual } from '~/lib/common/helpers/array'
 
 export type ProjectModelGroup = {
   projectId: string
@@ -884,13 +885,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         })
       }
     })
-  }
-
-  const arraysEqual = (a: string[] | undefined, b: string[] | undefined): boolean => {
-    if (a === b) return true
-    if (!a || !b) return false
-    if (a.length !== b.length) return false
-    return a.every((v, i) => v === b[i])
   }
 
   app.$baseBinding?.on(


### PR DESCRIPTION
## Description
Adds per-setting tooltips so labels can stay short while richer detail is available on hover. Fixes [CNX-3378](https://linear.app/speckle/issue/CNX-3378/add-tooltip-to-settings).

## User Value
Settings labels can be concise without sacrificing clarity — users get the longer explanation on demand.

## Changes:
- Added optional `Description` field to `CardSetting` (C# + TS).
- Added tooltips for all connector settings
- Extracted shared `FormJsonControlLabel` component, used by `BooleanControlRenderer` and `EnumControlRenderer` Tooltip is rendered via `v-tippy` on the label.
- Dropped `:help="control.description"` from the enum renderers — `description` now drives the tooltip, so leaving it on `:help` was duplicating it as inline helper text below the dropdown.
- Updated `tryToUpgradeModelCardSettings` to refresh `title`, `description`, `type`, and `enum` from the connector defaults on existing model cards, while preserving the user's chosen `value`. Without this, existing cards wouldn't see the new tooltips or the shortened titles.

## Validation of changes:
- Confirmed existing model cards pick up the new tooltips and shortened titles after the upgrade pass.
- Verified tooltip appears on hover for new publish or load actions.

### Existing model cards

https://github.com/user-attachments/assets/0e842903-2470-42c3-948e-718a0421e3ea

### New actions

https://github.com/user-attachments/assets/5c7f01b0-4cd1-426e-900f-266ccb48f2c2


## Checklist:
- [x] My commits are related to the pull request and do not amend unrelated code or documentation.
- [x] I have added appropriate tests.
- [x] I have updated or added relevant documentation.