### PR TITLE
fix(accounts): fall back to first accout when active account is removed

### DIFF
--- a/store/accounts.ts
+++ b/store/accounts.ts
@@ -54,10 +54,17 @@ export const useAccountStore = defineStore('accountStore', () => {
   const userSelectedAccount = ref<DUIAccount>()
 
   /**
-   * Returns either the default account or the last account the user has selected.
+   * Returns the user's selected account if it still exists, otherwise falls back to the first account.
    */
   const activeAccount = computed(() => {
-    return userSelectedAccount.value || accounts.value[0]
+    const selected = userSelectedAccount.value
+    if (
+      selected &&
+      accounts.value.some((a) => a.accountInfo.id === selected.accountInfo.id)
+    ) {
+      return selected
+    }
+    return accounts.value[0]
   })
 
   const removeAccount = async (acc: DUIAccount) => {


### PR DESCRIPTION
## Description

`userSelectedAccount` is a plain ref — after removal, `refreshAccounts()` rebuilds `accounts` without the deleted entry but the ref still points to the old object. The old computed `userSelectedAccount.value || accounts.value[0]`: stale ref is truthy, fallback never fires.

Computed now validates the selection against the live list on every evaluation.

## Changes

- `activeAccount` validates `userSelectedAccount` against the live `accounts` list, falls back to `accounts[0]` if stale

## Validation of changes

- Two accounts, remove the active one → workspace switcher reflects the remaining account immediately
- Remove a non-active account → no change to active account or workspaces