### PR TITLE
feat: filter out pre-releases

### DIFF
--- a/lib/core/composables/updateConnector.ts
+++ b/lib/core/composables/updateConnector.ts
@@ -60,7 +60,8 @@ export function useUpdateConnector() {
       }
 
       const data = (await response.json()) as unknown as Versions
-      const sortedVersions = data.Versions.sort(function (a: Version, b: Version) {
+      const stable = data.Versions.filter((v) => v.Prerelease !== true)
+      const sortedVersions = [...stable].sort(function (a: Version, b: Version) {
         return new Date(b.Date).getTime() - new Date(a.Date).getTime()
       })
       versions.value = sortedVersions


### PR DESCRIPTION
Filter out pre-releases to align logic with https://github.com/specklesystems/speckle-server-internal/blob/e2509f5d571a1bab444398d60988b56276a0a143/packages/frontend-3/lib/connectors/composables/useConnectorVersion.ts#L4


I've given the preview a quick spin already...