### PR TITLE
feat(analytics): migrate from Mixpanel to Posthog

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Start the development server on `http://localhost:8082`
 yarn dev
 ```
 
+Once you've got it running locally, you can run connectors with `SPECKLE_DUI_URL` env var set to `http://127.0.0.1:8082` (either system level, via CLI, or via launch/IDE configuration)
+see [connector-configuration](https://docs.speckle.systems/connectors/connector-configuration#self-hosting-desktop-ui) docs.
+
 ## Production
 
 Build the application for production:

--- a/README.md
+++ b/README.md
@@ -17,14 +17,13 @@ And create an `.env` file from `.env.example`.
 
 ## Development
 
-Start the development server on `http://localhost:8082`
+Start the development server on `http://localhost:8082/`
 
 ```bash
 yarn dev
 ```
 
-Once you've got it running locally, you can run connectors with `SPECKLE_DUI_URL` env var set to `http://127.0.0.1:8082` (either system level, via CLI, or via launch/IDE configuration)
-see [connector-configuration](https://docs.speckle.systems/connectors/connector-configuration#self-hosting-desktop-ui) docs.
+Once you've got it running locally, you can run connectors with [`SPECKLE_DUI_URL`](https://docs.speckle.systems/connectors/connector-configuration#self-hosting-desktop-ui) env var set to `http://127.0.0.1:8082` (via launch/IDE configuration)
 
 ## Production
 

--- a/app.vue
+++ b/app.vue
@@ -10,7 +10,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useConfigStore } from '~/store/config'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
@@ -39,22 +39,7 @@ useHead({
 })
 
 onMounted(() => {
-  const { trackEvent, addConnectorToProfile, identifyProfile } = useMixpanel()
-  // TODO: some host apps can open DUI3 automatically, with this case we shouldn't mark track event as `"type": "action"`,
-  // we need to get this info from source app. (TBD which apps: Rhino opens automatically, not sure acad, sketchup and revit needs trigger button to init)
-  trackEvent('DUI3 Action', { name: 'Launch' })
-
-  const { accounts } = useAccountStore()
-
-  const uniqueEmails = new Set<string>()
-  accounts.forEach((account) => {
-    const email = account?.accountInfo.userInfo.email
-    if (email && !uniqueEmails.has(email)) {
-      addConnectorToProfile(email)
-      identifyProfile(email)
-      uniqueEmails.add(email)
-    }
-  })
+  const { addConnectorToProfile, identifyProfile } = useAnalytics()
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { $intercom } = useNuxtApp() // needed her for initialisation

--- a/app.vue
+++ b/app.vue
@@ -10,9 +10,7 @@
   </div>
 </template>
 <script setup lang="ts">
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useConfigStore } from '~/store/config'
-import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 import { storeToRefs } from 'pinia'
 import { logToSeq } from '~/lib/logger/composables/useLogger'
@@ -39,8 +37,6 @@ useHead({
 })
 
 onMounted(() => {
-  const { addConnectorToProfile, identifyProfile } = useAnalytics()
-
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { $intercom } = useNuxtApp() // needed her for initialisation
 

--- a/components/accounts/ExchangeTokenSignInFlow.vue
+++ b/components/accounts/ExchangeTokenSignInFlow.vue
@@ -73,7 +73,7 @@
 import { ref } from 'vue'
 import { useAuthManager } from '~/lib/authn/useAuthManager'
 import { useTokenExchange, supportsOAuthToken } from '~/lib/authn/useTokenExchange'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { useAccountStore } from '~/store/accounts'
 import type { BaseBridge } from '~/lib/bridge/base'
 

--- a/components/accounts/ExchangeTokenSignInFlow.vue
+++ b/components/accounts/ExchangeTokenSignInFlow.vue
@@ -73,7 +73,7 @@
 import { ref } from 'vue'
 import { useAuthManager } from '~/lib/authn/useAuthManager'
 import { useTokenExchange, supportsOAuthToken } from '~/lib/authn/useTokenExchange'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useAccountStore } from '~/store/accounts'
 import type { BaseBridge } from '~/lib/bridge/base'
 
@@ -88,7 +88,7 @@ const emit = defineEmits<{
 const app = useNuxtApp()
 const { generateLocalChallenge } = useAuthManager()
 const { exchangeAccessCode } = useTokenExchange()
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const accountStore = useAccountStore()
 
 const { $accountBinding } = useNuxtApp()
@@ -148,13 +148,13 @@ const submitCode = async () => {
 
   state.value = 'submitting'
   try {
-    await exchangeAccessCode(
+    const acc = await exchangeAccessCode(
       currentServerUrl,
       code,
       currentCodeChallenge,
       currentCodeVerifier
     )
-    void trackEvent('DUI Account Added')
+    void trackEvent('DUI Account Added', acc)
     // Refresh accounts so the watcher in Menu.vue detects the new account and closes the dialog
     await accountStore.refreshAccounts()
   } catch (error) {

--- a/components/accounts/LegacySignInFlow.vue
+++ b/components/accounts/LegacySignInFlow.vue
@@ -54,7 +54,6 @@
 import { useIntervalFn } from '@vueuse/core'
 import { useHostAppStore } from '~/store/hostApp'
 import { ToastNotificationType } from '@speckle/ui-components'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
 import { useAccountStore } from '~~/store/accounts'
 import { useDesktopService } from '~/lib/core/composables/desktopService'
 import { ArrowLeftIcon } from '@heroicons/vue/24/solid'
@@ -63,7 +62,6 @@ const accountStore = useAccountStore()
 const { pingDesktopService } = useDesktopService()
 const hostApp = useHostAppStore()
 const app = useNuxtApp()
-const { trackEvent } = useMixpanel()
 
 const props = defineProps<{
   serverUrl: string
@@ -87,7 +85,6 @@ const accountCheckerIntervalFn = useIntervalFn(
       isAddingAccount.value = false
       showCustomServerInput.value = false
       accountCheckerIntervalFn.pause()
-      trackEvent('DUI Account Added')
     }
   },
   1000,

--- a/components/accounts/LegacySignInFlow.vue
+++ b/components/accounts/LegacySignInFlow.vue
@@ -56,10 +56,12 @@ import { useHostAppStore } from '~/store/hostApp'
 import { ToastNotificationType } from '@speckle/ui-components'
 import { useAccountStore } from '~~/store/accounts'
 import { useDesktopService } from '~/lib/core/composables/desktopService'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { ArrowLeftIcon } from '@heroicons/vue/24/solid'
 
 const accountStore = useAccountStore()
 const { pingDesktopService } = useDesktopService()
+const { trackEvent } = useAnalytics()
 const hostApp = useHostAppStore()
 const app = useNuxtApp()
 
@@ -78,13 +80,18 @@ const showHelp = ref(false)
 
 const accountCheckerIntervalFn = useIntervalFn(
   async () => {
-    const previousAccountCount = accountStore.accounts.length
+    const previousAccountIds = new Set(
+      accountStore.accounts.map((acc) => acc.accountInfo.id)
+    )
     await accountStore.refreshAccounts()
-    const currentAccountCount = accountStore.accounts.length
-    if (previousAccountCount !== currentAccountCount) {
+    const newAccount = accountStore.accounts.find(
+      (acc) => !previousAccountIds.has(acc.accountInfo.id)
+    )
+    if (newAccount) {
       isAddingAccount.value = false
       showCustomServerInput.value = false
       accountCheckerIntervalFn.pause()
+      void trackEvent('DUI Account Added', newAccount.accountInfo)
     }
   },
   1000,

--- a/components/accounts/Menu.vue
+++ b/components/accounts/Menu.vue
@@ -74,12 +74,10 @@ import { storeToRefs } from 'pinia'
 import { XMarkIcon } from '@heroicons/vue/20/solid'
 import type { DUIAccount } from '~/store/accounts'
 import { useAccountStore } from '~/store/accounts'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
 import { useDesktopService } from '~/lib/core/composables/desktopService'
 import type { BaseBridge } from '~/lib/bridge/base'
 import { useHostAppStore } from '~/store/hostApp'
 
-const { trackEvent } = useMixpanel()
 const app = useNuxtApp()
 const { pingDesktopService } = useDesktopService()
 const { $accountBinding } = useNuxtApp()
@@ -123,7 +121,6 @@ app.$baseBinding?.on('documentChanged', () => {
 watch(showAccountsDialog, (newVal) => {
   if (newVal) {
     void accountStore.refreshAccounts()
-    void trackEvent('DUI3 Action', { name: 'Account menu open' })
   }
 })
 
@@ -152,12 +149,10 @@ const selectAccount = (acc: DUIAccount) => {
   userSelectedAccount.value = acc
   accountStore.setUserSelectedAccount(acc) // saves the selected account id into DUI3Config.db for later use
   showAccountsDialog.value = false
-  void trackEvent('DUI3 Action', { name: 'Account change' })
 }
 
 const removeAccount = async (acc: DUIAccount) => {
   await accountStore.removeAccount(acc)
-  void trackEvent('DUI3 Action', { name: 'Account removed' })
 }
 
 const user = computed(() => {

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -32,7 +32,7 @@
               class="w-4 h-4"
               @click.stop="
                 $openUrl(projectUrl),
-                  trackEvent('DUI3 Action', { name: 'Project View' }, project.accountId)
+                  trackEvent('DUI3 Action', { name: 'Project View' }, project.accountId) //TODO: todo
               "
             />
           </div>
@@ -129,9 +129,9 @@ import {
   userProjectsUpdatedSubscription,
   projectUpdatedSubscription
 } from '~~/lib/graphql/mutationsAndQueries'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const accountStore = useAccountStore()
 const hostAppStore = useHostAppStore()
 const { $openUrl } = useNuxtApp()
@@ -316,14 +316,14 @@ userProjectsUpdated((res) => {
 })
 
 const projectUrl = computed(() => {
-  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId.value)
+  const acc = accountStore.getAccount(clientId.value)
   return `${acc?.accountInfo.serverInfo.url as string}/projects/${
     props.project.projectId
   }`
 })
 
 const workspaceUrl = computed(() => {
-  const acc = accountStore.accounts.find((acc) => acc.accountInfo.id === clientId.value)
+  const acc = accountStore.getAccount(clientId.value)
   return `${acc?.accountInfo.serverInfo.url as string}/workspaces/${
     projectDetails.value?.workspace?.slug
   }`

--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -30,10 +30,7 @@
           <div class="relative w-4 h-4">
             <ArrowTopRightOnSquareIcon
               class="w-4 h-4"
-              @click.stop="
-                $openUrl(projectUrl),
-                  trackEvent('DUI3 Action', { name: 'Project View' }, project.accountId) //TODO: todo
-              "
+              @click.stop="$openUrl(projectUrl)"
             />
           </div>
         </button>
@@ -129,9 +126,7 @@ import {
   userProjectsUpdatedSubscription,
   projectUpdatedSubscription
 } from '~~/lib/graphql/mutationsAndQueries'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 
-const { trackEvent } = useAnalytics()
 const accountStore = useAccountStore()
 const hostAppStore = useHostAppStore()
 const { $openUrl } = useNuxtApp()

--- a/components/feedback/Dialog.vue
+++ b/components/feedback/Dialog.vue
@@ -37,7 +37,7 @@
 import { ToastNotificationType, type LayoutDialogButton } from '@speckle/ui-components'
 import { useForm } from 'vee-validate'
 import { useZapier } from '~/lib/core/composables/zapier'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 
@@ -52,7 +52,7 @@ const props = defineProps<{
 
 const isOpen = defineModel<boolean>('open', { required: true })
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const { sendWebhook } = useZapier()
 const { handleSubmit } = useForm<FormValues>()
 const accountStore = useAccountStore()
@@ -81,8 +81,9 @@ const onSubmit = handleSubmit(async () => {
   if (!feedback.value) return
 
   isOpen.value = false
+  const account = accountStore.defaultAccount.accountInfo
 
-  trackEvent('Feedback Sent', {
+  trackEvent('Feedback Sent', account, {
     message: feedback.value,
     feedbackType: 'dui3',
     ...props.metadata
@@ -93,7 +94,7 @@ const onSubmit = handleSubmit(async () => {
     title: 'Thank you for your feedback!'
   })
 
-  const userId = accountStore.defaultAccount.accountInfo.userInfo.id ?? ''
+  const userId = account.userInfo.id ?? ''
 
   await sendWebhook('https://hooks.zapier.com/hooks/catch/12120532/2m4okri/', {
     userId,

--- a/components/feedback/Dialog.vue
+++ b/components/feedback/Dialog.vue
@@ -37,7 +37,7 @@
 import { ToastNotificationType, type LayoutDialogButton } from '@speckle/ui-components'
 import { useForm } from 'vee-validate'
 import { useZapier } from '~/lib/core/composables/zapier'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 

--- a/components/model/ActionsDialog.vue
+++ b/components/model/ActionsDialog.vue
@@ -73,13 +73,13 @@ import {
 import type { IModelCard } from '~/lib/models/card'
 import type { CardSetting } from '~/lib/models/card/setting'
 import { useHostAppStore } from '~/store/hostApp'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { issuesListQuery } from '~/lib/issues/graphql/queries'
 import { useAccountStore } from '~/store/accounts'
 import { storeToRefs } from 'pinia'
 import { useQuery } from '@vue/apollo-composable'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const store = useHostAppStore()
 
 const openModelCardActionsDialog = ref(false)

--- a/components/model/ActionsDialog.vue
+++ b/components/model/ActionsDialog.vue
@@ -73,7 +73,7 @@ import {
 import type { IModelCard } from '~/lib/models/card'
 import type { CardSetting } from '~/lib/models/card/setting'
 import { useHostAppStore } from '~/store/hostApp'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { issuesListQuery } from '~/lib/issues/graphql/queries'
 import { useAccountStore } from '~/store/accounts'
 import { storeToRefs } from 'pinia'
@@ -112,10 +112,15 @@ const items = [
     name: 'View 3D model in browser',
     icon: ArrowTopRightOnSquareIcon,
     action: () => {
-      void trackEvent('DUI3 Action', {
-        name: 'Version View',
-        source: 'model actions dialog'
-      })
+      const account = accountStore.getAccount(props.modelCard.accountId)
+      if (account) {
+        void trackEvent(
+          'DUI3 Action',
+          account.accountInfo,
+          { name: 'Version View', source: 'model actions dialog' },
+          props.modelCard.workspaceId
+        )
+      }
       emit('view')
       openModelCardActionsDialog.value = false
     }
@@ -124,10 +129,6 @@ const items = [
     name: 'View model versions',
     icon: ClockIcon,
     action: () => {
-      void trackEvent('DUI3 Action', {
-        name: 'Model History View',
-        source: 'model actions dialog'
-      })
       emit('view-versions')
       openModelCardActionsDialog.value = false
     }
@@ -137,7 +138,7 @@ const items = [
     danger: true,
     icon: ArchiveBoxXMarkIcon,
     action: () => {
-      // NOTE: Mixpanel event tracking is in host app store
+      // NOTE: analytics event tracking is in host app store
       emit('remove')
       openModelCardActionsDialog.value = false
     }

--- a/components/model/CardBase.vue
+++ b/components/model/CardBase.vue
@@ -250,7 +250,7 @@ import { useHostAppStore } from '~~/store/hostApp'
 import type { IModelCard } from '~~/lib/models/card'
 import { useAccountStore } from '~/store/accounts'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useIntervalFn, useTimeoutFn } from '@vueuse/core'
 import type { ProjectCommentsUpdatedMessage } from '~/lib/common/generated/gql/graphql'
 import { useFunctionRunsStatusSummary } from '~/lib/automate/runStatus'
@@ -262,7 +262,8 @@ import { MessageCircleMore } from 'lucide-vue-next'
 const app = useNuxtApp()
 const store = useHostAppStore()
 const accStore = useAccountStore()
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
+const accountStore = useAccountStore()
 
 const props = withDefaults(
   defineProps<{
@@ -389,9 +390,14 @@ const highlightModel = () => {
     })
     return
   }
-
+  const acc = accountStore.getAccount(props.modelCard.accountId).accountInfo
   app.$baseBinding.highlightModel(props.modelCard.modelCardId)
-  trackEvent('DUI3 Action', { name: 'Highlight Model' }, props.modelCard.accountId)
+  trackEvent(
+    'DUI3 Action',
+    acc,
+    { name: 'Highlight Model' },
+    props.modelCard.workspaceId
+  )
 }
 
 const isSettingsMissing = computed(() =>

--- a/components/model/CardBase.vue
+++ b/components/model/CardBase.vue
@@ -250,7 +250,7 @@ import { useHostAppStore } from '~~/store/hostApp'
 import type { IModelCard } from '~~/lib/models/card'
 import { useAccountStore } from '~/store/accounts'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { useIntervalFn, useTimeoutFn } from '@vueuse/core'
 import type { ProjectCommentsUpdatedMessage } from '~/lib/common/generated/gql/graphql'
 import { useFunctionRunsStatusSummary } from '~/lib/automate/runStatus'
@@ -263,7 +263,6 @@ const app = useNuxtApp()
 const store = useHostAppStore()
 const accStore = useAccountStore()
 const { trackEvent } = useAnalytics()
-const accountStore = useAccountStore()
 
 const props = withDefaults(
   defineProps<{
@@ -390,14 +389,16 @@ const highlightModel = () => {
     })
     return
   }
-  const acc = accountStore.getAccount(props.modelCard.accountId).accountInfo
   app.$baseBinding.highlightModel(props.modelCard.modelCardId)
-  trackEvent(
-    'DUI3 Action',
-    acc,
-    { name: 'Highlight Model' },
-    props.modelCard.workspaceId
-  )
+  const account = accStore.getAccount(props.modelCard.accountId)
+  if (account) {
+    trackEvent(
+      'DUI3 Action',
+      account.accountInfo,
+      { name: 'Highlight Model' },
+      props.modelCard.workspaceId
+    )
+  }
 }
 
 const isSettingsMissing = computed(() =>
@@ -427,7 +428,15 @@ const isReceiveSettingsMissing = computed(
 
 const viewModel = () => {
   // previously with DUI2, it was Stream View but actually it is "Version View" now. Also having conflict with old/new terminology.
-  trackEvent('DUI3 Action', { name: 'Version View' }, props.modelCard.accountId)
+  const account = accStore.getAccount(props.modelCard.accountId)
+  if (account) {
+    trackEvent(
+      'DUI3 Action',
+      account.accountInfo,
+      { name: 'Version View' },
+      props.modelCard.workspaceId
+    )
+  }
   app.$baseBinding.openUrl(
     `${projectAccount.value.accountInfo.serverInfo.url}/projects/${props.modelCard?.projectId}/models/${props.modelCard.modelId}`
   )
@@ -542,7 +551,6 @@ onCommentResult((res) => {
 })
 
 const viewComment = () => {
-  trackEvent('DUI3 Action', { name: 'Comment View' }, props.modelCard.accountId)
   if (!latestCommentNotification.value?.comment) return
 
   const commentId =

--- a/components/model/Receiver.vue
+++ b/components/model/Receiver.vue
@@ -101,12 +101,12 @@ import { useHostAppStore } from '~/store/hostApp'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
 import { versionDetailsQuery } from '~/lib/graphql/mutationsAndQueries'
 import type { VersionListItemFragment } from '~/lib/common/generated/gql/graphql'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useInterval, watchOnce } from '@vueuse/core'
 import { useAccountStore } from '~~/store/accounts'
 import type { CardSetting } from '~/lib/models/card/setting'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const app = useNuxtApp()
 const accountStore = useAccountStore()
 

--- a/components/model/Receiver.vue
+++ b/components/model/Receiver.vue
@@ -101,12 +101,10 @@ import { useHostAppStore } from '~/store/hostApp'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
 import { versionDetailsQuery } from '~/lib/graphql/mutationsAndQueries'
 import type { VersionListItemFragment } from '~/lib/common/generated/gql/graphql'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useInterval, watchOnce } from '@vueuse/core'
 import { useAccountStore } from '~~/store/accounts'
 import type { CardSetting } from '~/lib/models/card/setting'
 
-const { trackEvent } = useAnalytics()
 const app = useNuxtApp()
 const accountStore = useAccountStore()
 
@@ -166,10 +164,6 @@ const handleVersionSelection = async (
   latestVersion: VersionListItemFragment
 ) => {
   openVersionsDialog.value = false
-  void trackEvent('DUI3 Action', {
-    name: 'Load Card Version Change',
-    isLatestVersion: selectedVersion === latestVersion
-  })
   if (props.modelCard.progress) {
     await store.receiveModelCancel(props.modelCard.modelCardId)
   }

--- a/components/model/Sender.vue
+++ b/components/model/Sender.vue
@@ -126,7 +126,7 @@ import type { ModelCardNotification } from '~/lib/models/card/notification'
 import type { ISendFilter, ISenderModelCard } from '~/lib/models/card/send'
 import type { ProjectModelGroup } from '~/store/hostApp'
 import { useHostAppStore } from '~/store/hostApp'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { ToastNotificationType, ValidationHelpers } from '@speckle/ui-components'
 import {
   provideApolloClient,
@@ -224,10 +224,18 @@ const isSaveDisabled = computed(() => {
 
 const saveFilter = async () => {
   if (!newFilter.value) return // Safety check
-  void trackEvent('DUI3 Action', {
-    name: 'Publish Card Filter Change',
-    filter: newFilter.value.typeDiscriminator
-  })
+  const account = accountStore.getAccount(props.modelCard.accountId)
+  if (account) {
+    void trackEvent(
+      'DUI3 Action',
+      account.accountInfo,
+      {
+        name: 'Publish Card Filter Change',
+        filter: newFilter.value.typeDiscriminator
+      },
+      props.modelCard.workspaceId
+    )
+  }
 
   // do not reset idmap while creating a new one because it is managed by host app
   newFilter.value.idMap = props.modelCard.sendFilter?.idMap
@@ -249,9 +257,15 @@ const setVersionMessage = async (message: string) => {
     return
   }
 
-  void trackEvent('DUI3 Action', {
-    name: 'Set version message'
-  })
+  const account = accountStore.getAccount(props.modelCard.accountId)
+  if (account) {
+    void trackEvent(
+      'DUI3 Action',
+      account.accountInfo,
+      { name: 'Set version message' },
+      props.modelCard.workspaceId
+    )
+  }
 
   isUpdatingVersionMessage.value = true
   const client = projectAccount.value?.client as ApolloClient<unknown> | undefined

--- a/components/model/Sender.vue
+++ b/components/model/Sender.vue
@@ -126,7 +126,7 @@ import type { ModelCardNotification } from '~/lib/models/card/notification'
 import type { ISendFilter, ISenderModelCard } from '~/lib/models/card/send'
 import type { ProjectModelGroup } from '~/store/hostApp'
 import { useHostAppStore } from '~/store/hostApp'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { ToastNotificationType, ValidationHelpers } from '@speckle/ui-components'
 import {
   provideApolloClient,
@@ -142,7 +142,7 @@ import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
 const store = useHostAppStore()
 const accountStore = useAccountStore()
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const app = useNuxtApp()
 const { canCreateModelIngestion } = useCheckGraphql()
 

--- a/components/receive/Wizard.vue
+++ b/components/receive/Wizard.vue
@@ -60,13 +60,11 @@ import type {
 import { useHostAppStore } from '~/store/hostApp'
 import { useAccountStore } from '~/store/accounts'
 import { ReceiverModelCard } from '~/lib/models/card/receiver'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useSettingsTracking } from '~/lib/core/composables/trackSettings'
 import { useAddByUrl } from '~/lib/core/composables/addByUrl'
 import { getSlugFromHostAppNameAndVersion } from '~/lib/common/helpers/hostAppSlug'
 import type { CardSetting } from '~/lib/models/card/setting'
 
-const { trackEvent } = useAnalytics()
 const { trackSettingsChange } = useSettingsTracking()
 
 const showReceiveDialog = defineModel<boolean>('open', { default: false })
@@ -125,14 +123,11 @@ const selectProject = (
   selectedAccountId.value = accountId
   selectedProject.value = project
   selectedWorkspace.value = workspace
-
-  void trackEvent('DUI3 Action', { name: 'Load Wizard', step: 'project selected' })
 }
 
 const selectModel = (model: ModelListModelItemFragment) => {
   step.value++
   selectedModel.value = model
-  void trackEvent('DUI3 Action', { name: 'Load Wizard', step: 'model selected' })
 }
 
 const title = computed(() => {
@@ -152,11 +147,7 @@ const selectVersionAndAddModel = async (
   version: VersionListItemFragment,
   latestVersion: VersionListItemFragment
 ) => {
-  void trackEvent('DUI3 Action', {
-    name: 'Load Wizard',
-    step: 'version selected',
-    hasSelectedLatestVersion: version.id === latestVersion.id
-  })
+  const account = accountStore.getAccount(selectedAccountId.value)
 
   const existingModel = hostAppStore.models.find(
     (m) =>
@@ -171,8 +162,9 @@ const selectVersionAndAddModel = async (
       'Load Settings Changed',
       receieveSettings.value,
       existingModel?.settings || hostAppStore.receiveSettings || [],
-      selectedAccountId.value,
-      true
+      account?.accountInfo,
+      true,
+      selectedWorkspace.value?.id
     )
   }
 

--- a/components/receive/Wizard.vue
+++ b/components/receive/Wizard.vue
@@ -60,13 +60,13 @@ import type {
 import { useHostAppStore } from '~/store/hostApp'
 import { useAccountStore } from '~/store/accounts'
 import { ReceiverModelCard } from '~/lib/models/card/receiver'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useSettingsTracking } from '~/lib/core/composables/trackSettings'
 import { useAddByUrl } from '~/lib/core/composables/addByUrl'
 import { getSlugFromHostAppNameAndVersion } from '~/lib/common/helpers/hostAppSlug'
 import type { CardSetting } from '~/lib/models/card/setting'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const { trackSettingsChange } = useSettingsTracking()
 
 const showReceiveDialog = defineModel<boolean>('open', { default: false })

--- a/components/report/Item.vue
+++ b/components/report/Item.vue
@@ -97,7 +97,7 @@ const isSender = computed(() =>
     .includes('sender')
 )
 
-const acc = accStore.accounts.find((acc) => acc.accountInfo.id === cardBase.accountId)
+const acc = accStore.getAccount(cardBase.accountId)
 
 const details = computed(() =>
   props.reportItem.error

--- a/components/send/Wizard.vue
+++ b/components/send/Wizard.vue
@@ -70,14 +70,14 @@ import { SenderModelCard } from '~/lib/models/card/send'
 import { useHostAppStore } from '~/store/hostApp'
 import { useAccountStore } from '~/store/accounts'
 import { useSelectionStore } from '~/store/selection'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useSettingsTracking } from '~/lib/core/composables/trackSettings'
 import type { CardSetting } from '~/lib/models/card/setting'
 import { useAddByUrl } from '~/lib/core/composables/addByUrl'
 import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
 import { workspacePlanUsageUpdatedSubscription } from '~/lib/workspaces/graphql/subscriptions'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const { trackSettingsChange } = useSettingsTracking()
 
 const showSendDialog = defineModel<boolean>('open', { default: false })

--- a/components/send/Wizard.vue
+++ b/components/send/Wizard.vue
@@ -70,14 +70,12 @@ import { SenderModelCard } from '~/lib/models/card/send'
 import { useHostAppStore } from '~/store/hostApp'
 import { useAccountStore } from '~/store/accounts'
 import { useSelectionStore } from '~/store/selection'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useSettingsTracking } from '~/lib/core/composables/trackSettings'
 import type { CardSetting } from '~/lib/models/card/setting'
 import { useAddByUrl } from '~/lib/core/composables/addByUrl'
 import { useCheckGraphql } from '~/lib/core/composables/useCheckGraphql'
 import { workspacePlanUsageUpdatedSubscription } from '~/lib/workspaces/graphql/subscriptions'
 
-const { trackEvent } = useAnalytics()
 const { trackSettingsChange } = useSettingsTracking()
 
 const showSendDialog = defineModel<boolean>('open', { default: false })
@@ -204,7 +202,6 @@ const selectProject = (accountId: string, project: ProjectListProjectItemFragmen
   step.value++
   selectedAccountId.value = accountId
   selectedProject.value = project
-  void trackEvent('DUI3 Action', { name: 'Publish Wizard', step: 'project selected' })
 }
 
 const title = computed(() => {
@@ -217,16 +214,11 @@ const title = computed(() => {
 const selectModel = (model: ModelListModelItemFragment) => {
   step.value++
   selectedModel.value = model
-  void trackEvent('DUI3 Action', { name: 'Publish Wizard', step: 'model selected' })
 }
 
 // accountId, serverUrl, projectId, modelId, sendFilter, settings
 const addModel = async () => {
-  void trackEvent('DUI3 Action', {
-    name: 'Publish Wizard',
-    step: 'objects selected',
-    filter: filter.value?.typeDiscriminator
-  })
+  const account = accountStore.getAccount(selectedAccountId.value)
 
   const existingModel = hostAppStore.models.find(
     (m) =>
@@ -241,8 +233,9 @@ const addModel = async () => {
       'Publish Settings Changed',
       settings.value,
       existingModel?.settings || hostAppStore.sendSettings || [],
-      selectedAccountId.value,
-      true
+      account?.accountInfo,
+      true,
+      workspaceId.value
     )
   }
   if (existingModel) {

--- a/components/wizard/ModelSelector.vue
+++ b/components/wizard/ModelSelector.vue
@@ -151,7 +151,7 @@ import {
 import type { DUIAccount } from '~/store/accounts'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 
 const { trackEvent } = useAnalytics()
 const hostAppStore = useHostAppStore()
@@ -235,7 +235,12 @@ const createNewModel = async (name: string) => {
 
   isCreatingModel.value = true
 
-  void trackEvent('DUI3 Action', { name: 'Model Create' }, account.value.accountInfo.id)
+  void trackEvent(
+    'DUI3 Action',
+    account.value.accountInfo,
+    { name: 'Model Create' },
+    props.workspaceId
+  )
 
   const { mutate } = provideApolloClient(account.value.client)(() =>
     useMutation(createModelMutation)

--- a/components/wizard/ModelSelector.vue
+++ b/components/wizard/ModelSelector.vue
@@ -151,9 +151,9 @@ import {
 import type { DUIAccount } from '~/store/accounts'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const hostAppStore = useHostAppStore()
 
 const emit = defineEmits<{

--- a/components/wizard/ProjectSelector.vue
+++ b/components/wizard/ProjectSelector.vue
@@ -218,12 +218,12 @@ import type {
   ProjectListProjectItemFragment,
   WorkspaceListWorkspaceItemFragment
 } from '~/lib/common/generated/gql/graphql'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import { useConfigStore } from '~/store/config'
 import { useHostAppStore } from '~/store/hostApp'
 
 const hostAppStore = useHostAppStore()
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 const { $openUrl } = useNuxtApp()
 
 const emit = defineEmits<{

--- a/components/wizard/ProjectSelector.vue
+++ b/components/wizard/ProjectSelector.vue
@@ -218,7 +218,7 @@ import type {
   ProjectListProjectItemFragment,
   WorkspaceListWorkspaceItemFragment
 } from '~/lib/common/generated/gql/graphql'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import { useConfigStore } from '~/store/config'
 import { useHostAppStore } from '~/store/hostApp'
 
@@ -268,7 +268,7 @@ const selectAccount = (account: DUIAccount) => {
   refetchServerInfo() // to be able to understand workspaces enabled or not
   refetchActiveWorkspace()
   refetchWorkspaces()
-  void trackEvent('DUI3 Action', { name: 'Account Select' }, account.accountInfo.id)
+  void trackEvent('DUI3 Action', account.accountInfo, { name: 'Account Select' })
 }
 
 const handleProjectCreated = (result: ProjectListProjectItemFragment) => {
@@ -519,11 +519,10 @@ const account = computed(() => {
 
 const createNewWorkspaceProject = async (name: string) => {
   isCreatingProject.value = true
-  void trackEvent(
-    'DUI3 Action',
-    { name: 'Project Create', workspace: true },
-    accountId.value
-  )
+  void trackEvent('DUI3 Action', account.value.accountInfo, {
+    name: 'Project Create',
+    workspace: true
+  })
   const { mutate, onError } = provideApolloClient(account.value.client)(() =>
     useMutation(createProjectInWorkspaceMutation)
   )
@@ -549,11 +548,10 @@ const createNewWorkspaceProject = async (name: string) => {
 const createNewPersonalProject = async (name: string) => {
   isCreatingProject.value = true
 
-  void trackEvent(
-    'DUI3 Action',
-    { name: 'Project Create', workspace: false },
-    account.value.accountInfo.id
-  )
+  void trackEvent('DUI3 Action', account.value.accountInfo, {
+    name: 'Project Create',
+    workspace: false
+  })
 
   const { mutate, onError } = provideApolloClient(account.value.client)(() =>
     useMutation(createProjectMutation)

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 # NODE_ENV must be set after the dependencies are installed because @nuxt/kit is a devDependency and is required to build the application
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-ENV NUXT_PUBLIC_POSTHOG_API_KEY=acd87c5a50b56df91a795e999812a3a4
+ENV NUXT_PUBLIC_POSTHOG_API_KEY=phc_7zaDwBgrBYb1yUe0Ff3Sn0DUibq0NoPNxYNC90M7cfg
 ENV NUXT_PUBLIC_POSTHOG_API_HOST="eu.i.posthog.com"
 # Browser OpenTelemetry (HyperDX RUM). Static SPA → config is baked at build time;
 # override per-deployment with --build-arg. service.name is fixed to "speckle-dui".

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -9,8 +9,8 @@ COPY . .
 # NODE_ENV must be set after the dependencies are installed because @nuxt/kit is a devDependency and is required to build the application
 ARG NODE_ENV=production
 ENV NODE_ENV=${NODE_ENV}
-ENV NUXT_PUBLIC_MIXPANEL_TOKEN_ID=acd87c5a50b56df91a795e999812a3a4
-ENV NUXT_PUBLIC_MIXPANEL_API_HOST=https://analytics.speckle.systems
+ENV NUXT_PUBLIC_POSTHOG_API_KEY=acd87c5a50b56df91a795e999812a3a4
+ENV NUXT_PUBLIC_POSTHOG_API_HOST="eu.i.posthog.com"
 # Browser OpenTelemetry (HyperDX RUM). Static SPA → config is baked at build time;
 # override per-deployment with --build-arg. service.name is fixed to "speckle-dui".
 ARG NUXT_PUBLIC_HYPERDX_ENABLED=false

--- a/env.example
+++ b/env.example
@@ -1,8 +1,8 @@
 HOST=127.0.0.1
 PORT=8082
 
-NUXT_PUBLIC_MIXPANEL_TOKEN_ID=acd87c5a50b56df91a795e999812a3a4
-NUXT_PUBLIC_MIXPANEL_API_HOST=https://analytics.speckle.systems
+NUXT_PUBLIC_POSTHOG_API_KEY="phc_7zaDwBgrBYb1yUe0Ff3Sn0DUibq0NoPNxYNC90M7cfg"
+NUXT_PUBLIC_POSTHOG_API_HOST="eu.i.posthog.com"
 
 # Browser OpenTelemetry / HyperDX RUM (baked at build time, see deployment/docker/Dockerfile)
 NUXT_PUBLIC_HYPERDX_ENABLED=false

--- a/lib/authn/useTokenExchange.ts
+++ b/lib/authn/useTokenExchange.ts
@@ -22,7 +22,7 @@ export function useTokenExchange() {
     accessCode: string,
     challenge: string,
     codeVerifier?: string
-  ): Promise<void> => {
+  ): Promise<Account> => {
     // Normalize to origin (strips trailing slash, path, etc.)
     // so account IDs stay consistent with connectors
     const serverUrl = new URL(rawServerUrl).origin
@@ -108,6 +108,7 @@ export function useTokenExchange() {
     }
 
     await $accountBinding.addAccount(accountId, account)
+    return account
   }
 
   return { exchangeAccessCode }

--- a/lib/bindings/definitions/IConfigBinding.ts
+++ b/lib/bindings/definitions/IConfigBinding.ts
@@ -24,6 +24,7 @@ export interface IConfigBinding extends IBinding<IConfigBindingEvents> {
   getAccountsConfig: () => Promise<AccountsConfig> // should have been named like this from day 0. we should get rid of `getUserSelectedAccountId` function after some amount of time to not confuse ourselves.
   setUserSelectedWorkspaceId: (workspaceId: string) => void
   getWorkspacesConfig: () => Promise<WorkspacesConfig>
+  getSessionId: () => Promise<string | null>
 }
 
 export interface IConfigBindingEvents extends IBindingSharedEvents {}
@@ -58,7 +59,8 @@ export class MockedConfigBinding implements IConfigBinding {
     'getWorkspacesConfig',
     'getUserSelectedAccountId',
     'showDevTools',
-    'openUrl'
+    'openUrl',
+    'getSessionId'
   ]
   public async getIsDevMode() {
     return true
@@ -105,6 +107,10 @@ export class MockedConfigBinding implements IConfigBinding {
 
   public async openUrl(url: string) {
     window.open(url)
+  }
+
+  public async getSessionId() {
+    return null
   }
 
   public on() {

--- a/lib/bridge/generic.ts
+++ b/lib/bridge/generic.ts
@@ -34,8 +34,8 @@ export class GenericBridge extends BaseBridge {
 
     try {
       this.availableMethodNames = await this.bridge.GetBindingsMethodNames()
-    } catch {
-      console.warn(`Failed to get method names from binding.`)
+    } catch (error) {
+      console.warn(`Failed to get method names from binding.`, error)
       return false
     }
 

--- a/lib/common/generated/gql/graphql.ts
+++ b/lib/common/generated/gql/graphql.ts
@@ -4120,6 +4120,7 @@ export type Mutation = {
   webhookUpdate: Scalars['String']['output'];
   workspaceJoinRequestMutations: WorkspaceJoinRequestMutations;
   workspaceMutations: WorkspaceMutations;
+  workspaceSandboxMutations: WorkspaceSandboxMutations;
 };
 
 
@@ -5787,6 +5788,38 @@ export enum ProjectVisibility {
   Workspace = 'WORKSPACE'
 }
 
+/** Bentley cloud (iTwin) browsing surface, reached via `ProjectWiseIntegration.cloud`. */
+export type ProjectWiseCloudIntegration = {
+  __typename?: 'ProjectWiseCloudIntegration';
+  folder: ProjectWiseFolder;
+  iTwin: ProjectWiseiTwin;
+  iTwins: ProjectWiseiTwinCollection;
+  /**
+   * Resolve a ProjectWise Design Integration folder by id, scoped to a specific
+   * Work Area Connection (via its `url`).
+   */
+  pwdiFolder: ProjectWisePwdiFolder;
+};
+
+
+/** Bentley cloud (iTwin) browsing surface, reached via `ProjectWiseIntegration.cloud`. */
+export type ProjectWiseCloudIntegrationFolderArgs = {
+  folderId: Scalars['String']['input'];
+};
+
+
+/** Bentley cloud (iTwin) browsing surface, reached via `ProjectWiseIntegration.cloud`. */
+export type ProjectWiseCloudIntegrationITwinArgs = {
+  id: Scalars['String']['input'];
+};
+
+
+/** Bentley cloud (iTwin) browsing surface, reached via `ProjectWiseIntegration.cloud`. */
+export type ProjectWiseCloudIntegrationPwdiFolderArgs = {
+  connectionUrl: Scalars['String']['input'];
+  folderId: Scalars['String']['input'];
+};
+
 export type ProjectWiseFile = {
   __typename?: 'ProjectWiseFile';
   displayName: Scalars['String']['output'];
@@ -5818,37 +5851,117 @@ export type ProjectWiseFolderCollection = {
   items: Array<ProjectWiseFolder>;
 };
 
+/**
+ * Namespace grouping every ProjectWise browsing entry point for a single
+ * workspace: cloud (iTwin) access, on-premises native WSG Basic Auth (ad-hoc or
+ * via a saved credential) and the caller's saved credentials.
+ */
 export type ProjectWiseIntegration = {
   __typename?: 'ProjectWiseIntegration';
-  folder: ProjectWiseFolder;
-  iTwin: ProjectWiseiTwin;
-  iTwins: ProjectWiseiTwinCollection;
+  /** Bentley cloud (iTwin) browsing via an OAuth access token obtained by the client. */
+  cloud?: Maybe<ProjectWiseCloudIntegration>;
   /**
-   * Resolve a ProjectWise Design Integration folder by id, scoped to a specific
-   * Work Area Connection (via its `url`).
+   * List saved ProjectWise Basic Auth credentials for the calling user in this
+   * workspace. Passwords are never returned — use `stored` to browse using saved
+   * credentials.
    */
-  pwdiFolder: ProjectWisePwdiFolder;
+  credentials: Array<SavedProjectwiseCredential>;
+  /**
+   * Entry point for on-premises ProjectWise via native WSG Basic Auth.
+   * Credentials are passed per-request and never stored server-side.
+   */
+  native?: Maybe<ProjectWiseNativeIntegration>;
+  /**
+   * Entry point for on-premises ProjectWise using a previously saved credential.
+   * The server decrypts the stored credentials and uses them for the request.
+   */
+  stored?: Maybe<ProjectWiseNativeIntegration>;
 };
 
 
-export type ProjectWiseIntegrationFolderArgs = {
-  folderId: Scalars['String']['input'];
+/**
+ * Namespace grouping every ProjectWise browsing entry point for a single
+ * workspace: cloud (iTwin) access, on-premises native WSG Basic Auth (ad-hoc or
+ * via a saved credential) and the caller's saved credentials.
+ */
+export type ProjectWiseIntegrationCloudArgs = {
+  token: Scalars['String']['input'];
 };
 
 
-export type ProjectWiseIntegrationITwinArgs = {
-  id: Scalars['String']['input'];
+/**
+ * Namespace grouping every ProjectWise browsing entry point for a single
+ * workspace: cloud (iTwin) access, on-premises native WSG Basic Auth (ad-hoc or
+ * via a saved credential) and the caller's saved credentials.
+ */
+export type ProjectWiseIntegrationNativeArgs = {
+  password: Scalars['String']['input'];
+  username: Scalars['String']['input'];
+  wsgUrl: Scalars['String']['input'];
 };
 
 
-export type ProjectWiseIntegrationPwdiFolderArgs = {
-  connectionUrl: Scalars['String']['input'];
-  folderId: Scalars['String']['input'];
+/**
+ * Namespace grouping every ProjectWise browsing entry point for a single
+ * workspace: cloud (iTwin) access, on-premises native WSG Basic Auth (ad-hoc or
+ * via a saved credential) and the caller's saved credentials.
+ */
+export type ProjectWiseIntegrationStoredArgs = {
+  credentialId: Scalars['ID']['input'];
 };
 
 export type ProjectWiseItemCollection = {
   __typename?: 'ProjectWiseItemCollection';
   items: Array<ProjectWiseStorageItem>;
+};
+
+export type ProjectWiseNativeDatasource = {
+  __typename?: 'ProjectWiseNativeDatasource';
+  folder?: Maybe<ProjectWiseNativeFolder>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  rootFolders: Array<ProjectWiseNativeFolder>;
+  wsgUrl: Scalars['String']['output'];
+};
+
+
+export type ProjectWiseNativeDatasourceFolderArgs = {
+  id: Scalars['ID']['input'];
+};
+
+export type ProjectWiseNativeFile = {
+  __typename?: 'ProjectWiseNativeFile';
+  datasourceId: Scalars['String']['output'];
+  fileName?: Maybe<Scalars['String']['output']>;
+  fileSize?: Maybe<Scalars['Int']['output']>;
+  id: Scalars['ID']['output'];
+  name: Scalars['String']['output'];
+  parentFolderId?: Maybe<Scalars['String']['output']>;
+  updateTime?: Maybe<Scalars['String']['output']>;
+  wsgUrl: Scalars['String']['output'];
+};
+
+export type ProjectWiseNativeFolder = {
+  __typename?: 'ProjectWiseNativeFolder';
+  children: Array<ProjectWiseNativeFolder>;
+  datasourceId: Scalars['String']['output'];
+  files: Array<ProjectWiseNativeFile>;
+  id: Scalars['ID']['output'];
+  isRichProject: Scalars['Boolean']['output'];
+  name: Scalars['String']['output'];
+  wsgUrl: Scalars['String']['output'];
+};
+
+export type ProjectWiseNativeIntegration = {
+  __typename?: 'ProjectWiseNativeIntegration';
+  datasource?: Maybe<ProjectWiseNativeDatasource>;
+  datasources: Array<ProjectWiseNativeDatasource>;
+  wsgUrl: Scalars['String']['output'];
+};
+
+
+export type ProjectWiseNativeIntegrationDatasourceArgs = {
+  id: Scalars['ID']['input'];
 };
 
 export type ProjectWisePwdiFile = {
@@ -5982,6 +6095,14 @@ export type PublicAiConversation = {
   id: Scalars['ID']['output'];
   messages: Array<Scalars['JSONObject']['output']>;
   projectId?: Maybe<Scalars['String']['output']>;
+  /**
+   * Presigned snapshot URLs for the data warehouse tables this conversation's
+   * reports depend on, so a shared report can re-attach and re-render them
+   * client-side (the share token has no workspace access to fetch them itself).
+   * Scoped to ONLY the sources the conversation actually references; empty when the
+   * warehouses module is disabled or no warehouse sources are used.
+   */
+  reportDataSourceSnapshots: Array<PublicReportDataSourceSnapshot>;
   surface: Scalars['String']['output'];
   title: Scalars['String']['output'];
   updatedAt: Scalars['DateTime']['output'];
@@ -6003,8 +6124,31 @@ export type PublicReport = {
   layout: Scalars['JSONObject']['output'];
   name: Scalars['String']['output'];
   projectId: Scalars['String']['output'];
+  /**
+   * Presigned snapshots for the data warehouse tables this shared report's
+   * bindings depend on (extracted from the saved layout's `section.datasources`).
+   * The share token has no workspace access, so the server presigns them here —
+   * scoped to ONLY the sources the report references. Empty when the warehouses
+   * module is disabled or nothing is referenced. The existing snapshot is served
+   * as-is (no refresh) so an anonymous public load never triggers warehouse
+   * materialisation.
+   */
+  reportDataSourceSnapshots: Array<PublicReportDataSourceSnapshot>;
   schemaVersion: Scalars['Int']['output'];
   updatedAt: Scalars['DateTime']['output'];
+};
+
+/**
+ * A presigned snapshot of a data warehouse source a shared report depends on.
+ * `alias` is the SQL identifier the report's bindings reference; `url` is a
+ * short-lived download URL for the source's `.duckdb` snapshot.
+ */
+export type PublicReportDataSourceSnapshot = {
+  __typename?: 'PublicReportDataSourceSnapshot';
+  alias: Scalars['String']['output'];
+  filename: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  url: Scalars['String']['output'];
 };
 
 export type PublicShareTokenInfo = {
@@ -6730,6 +6874,30 @@ export type RootPermissionChecks = {
   canSupportServerUsers: PermissionCheckResult;
   canUpdateServerSettings: PermissionCheckResult;
   canUsePowerTools: PermissionCheckResult;
+};
+
+export type SaveProjectwiseCredentialInput = {
+  datasourceId: Scalars['String']['input'];
+  datasourceName: Scalars['String']['input'];
+  password: Scalars['String']['input'];
+  username: Scalars['String']['input'];
+  workspaceId: Scalars['String']['input'];
+  wsgUrl: Scalars['String']['input'];
+};
+
+export type SaveProjectwiseCredentialResult = {
+  __typename?: 'SaveProjectwiseCredentialResult';
+  datasourceName: Scalars['String']['output'];
+  id: Scalars['String']['output'];
+  wsgUrl: Scalars['String']['output'];
+};
+
+export type SavedProjectwiseCredential = {
+  __typename?: 'SavedProjectwiseCredential';
+  datasourceId: Scalars['String']['output'];
+  datasourceName: Scalars['String']['output'];
+  id: Scalars['ID']['output'];
+  wsgUrl: Scalars['String']['output'];
 };
 
 export type SavedView = {
@@ -7732,6 +7900,12 @@ export type Subscription = {
    */
   workspaceProjectsUpdated: WorkspaceProjectsUpdatedMessage;
   /**
+   * Track when a newly created sandbox gets created and is ready to be used. Scoped to the
+   * authenticated user (from the auth token) - the event is only emitted to admins of the
+   * newly created sandbox workspace.
+   */
+  workspaceSandboxCreated: WorkspaceSandboxCreatedMessage;
+  /**
    * Track support session changes for a specific workspace.
    * Fires when sessions are requested, approved, revoked, or expire.
    */
@@ -8550,6 +8724,11 @@ export type UserMeta = {
   intelligenceCommunityStandUpBannerDismissed: Scalars['Boolean']['output'];
   legacyProjectsExplainerCollapsed: Scalars['Boolean']['output'];
   newWorkspaceExplainerDismissed: Scalars['Boolean']['output'];
+  /**
+   * Whether the sandbox walkthrough tour has been completed by this user.
+   * Reset to false on new sandbox creation so each fresh sandbox re-triggers the tour.
+   */
+  sandboxWalkthroughCompleted: Scalars['Boolean']['output'];
   speckleCon25BannerDismissed: Scalars['Boolean']['output'];
   speckleConBannerDismissed: Scalars['Boolean']['output'];
 };
@@ -8565,6 +8744,11 @@ export type UserMetaMutations = {
   setIntelligenceCommunityStandUpBannerDismissed: Scalars['Boolean']['output'];
   setLegacyProjectsExplainerCollapsed: Scalars['Boolean']['output'];
   setNewWorkspaceExplainerDismissed: Scalars['Boolean']['output'];
+  /**
+   * Set the sandbox walkthrough completion flag. Pass `true` when the tour finishes,
+   * `false` to restart it.
+   */
+  setSandboxWalkthroughCompleted: Scalars['Boolean']['output'];
   setSpeckleCon25BannerDismissed: Scalars['Boolean']['output'];
   setSpeckleConBannerDismissed: Scalars['Boolean']['output'];
 };
@@ -8587,6 +8771,11 @@ export type UserMetaMutationsSetLegacyProjectsExplainerCollapsedArgs = {
 
 
 export type UserMetaMutationsSetNewWorkspaceExplainerDismissedArgs = {
+  value: Scalars['Boolean']['input'];
+};
+
+
+export type UserMetaMutationsSetSandboxWalkthroughCompletedArgs = {
   value: Scalars['Boolean']['input'];
 };
 
@@ -9583,16 +9772,17 @@ export type WorkspaceIdentifier = {
 export type WorkspaceIntegrations = {
   __typename?: 'WorkspaceIntegrations';
   acc?: Maybe<AccIntegration>;
+  /**
+   * Bentley ProjectWise integration entry point for this workspace. Nullable so
+   * that a disabled Bentley module / missing plan feature isolates to this field.
+   * Authorization (workspace membership + the `bentleyIntegration` plan feature)
+   * is enforced once here; the whole subtree below inherits it.
+   */
   projectWise?: Maybe<ProjectWiseIntegration>;
 };
 
 
 export type WorkspaceIntegrationsAccArgs = {
-  token?: InputMaybe<Scalars['String']['input']>;
-};
-
-
-export type WorkspaceIntegrationsProjectWiseArgs = {
   token?: InputMaybe<Scalars['String']['input']>;
 };
 
@@ -9855,6 +10045,11 @@ export type WorkspaceMutations = {
    * Irreversible.
    */
   deleteProjectMetadataSchema: Workspace;
+  /**
+   * Delete a saved ProjectWise credential. Caller must be the credential owner
+   * or a workspace admin.
+   */
+  deleteProjectwiseCredential: Scalars['Boolean']['output'];
   deleteSsoProvider: Scalars['Boolean']['output'];
   /** Revoke the SSO session for a specific user in a workspace. Only workspace admins can perform this action. */
   deleteSsoSession: Scalars['Boolean']['output'];
@@ -9869,6 +10064,11 @@ export type WorkspaceMutations = {
   projects: WorkspaceProjectMutations;
   regenerateScimToken: WorkspaceScimTokenResult;
   requestToJoin: Scalars['Boolean']['output'];
+  /**
+   * Save (upsert) an on-premises ProjectWise Basic Auth credential set for the
+   * calling user. Credentials are encrypted server-side before storage.
+   */
+  saveProjectwiseCredential: SaveProjectwiseCredentialResult;
   /** Set the default region where project data will be stored. Only available to admins. */
   setDefaultRegion: Workspace;
   setProjectMetadataSchema: Workspace;
@@ -9916,6 +10116,12 @@ export type WorkspaceMutationsDeleteProjectMetadataSchemaArgs = {
 };
 
 
+export type WorkspaceMutationsDeleteProjectwiseCredentialArgs = {
+  id: Scalars['String']['input'];
+  workspaceId: Scalars['String']['input'];
+};
+
+
 export type WorkspaceMutationsDeleteSsoProviderArgs = {
   workspaceId: Scalars['String']['input'];
 };
@@ -9954,6 +10160,11 @@ export type WorkspaceMutationsRegenerateScimTokenArgs = {
 
 export type WorkspaceMutationsRequestToJoinArgs = {
   input: WorkspaceRequestToJoinInput;
+};
+
+
+export type WorkspaceMutationsSaveProjectwiseCredentialArgs = {
+  input: SaveProjectwiseCredentialInput;
 };
 
 
@@ -10446,6 +10657,40 @@ export type WorkspaceRoleUpdateInput = {
   role?: InputMaybe<Scalars['String']['input']>;
   userId: Scalars['String']['input'];
   workspaceId: Scalars['String']['input'];
+};
+
+export type WorkspaceSandboxCreatedMessage = {
+  __typename?: 'WorkspaceSandboxCreatedMessage';
+  /** Workspace ID */
+  id: Scalars['String']['output'];
+  /** Workspace itself */
+  workspace: Workspace;
+};
+
+/** Pre-built example a sandbox can be populated from on creation. */
+export enum WorkspaceSandboxExampleInput {
+  AiReadyDashboards = 'AI_READY_DASHBOARDS',
+  CrossToolCollaborations = 'CROSS_TOOL_COLLABORATIONS',
+  ModelValidation = 'MODEL_VALIDATION'
+}
+
+export type WorkspaceSandboxMutations = {
+  __typename?: 'WorkspaceSandboxMutations';
+  /**
+   * Create a sandbox workspace. Sandboxes are created on the sandbox plan with a trial
+   * status and are automatically deleted once the trial expires. The name and slug are
+   * auto-generated, so no input is required. If the user already owns a sandbox, it is
+   * deleted before the new one is created.
+   *
+   * When `example` is provided, the sandbox is populated from the matching pre-built
+   * example workspace. When omitted, an empty sandbox is created.
+   */
+  create: Workspace;
+};
+
+
+export type WorkspaceSandboxMutationsCreateArgs = {
+  example?: InputMaybe<WorkspaceSandboxExampleInput>;
 };
 
 export type WorkspaceScimConfig = {

--- a/lib/core/composables/analytics.ts
+++ b/lib/core/composables/analytics.ts
@@ -35,7 +35,7 @@ export function useAnalytics() {
 
       const url = new URL(account.serverInfo.url)
 
-      if (url === new URL('https://app.speckle.systems')) {
+      if (url.origin !== 'https://app.speckle.systems') {
         // Right now, we're keeping posthog only for app.speckle.systems users
         return
       }

--- a/lib/core/composables/analytics.ts
+++ b/lib/core/composables/analytics.ts
@@ -22,12 +22,6 @@ export function useAnalytics() {
     customProperties: CustomProperties = {},
     workspaceId: string | null = null
   ) {
-    // TODO: enable it later somehow
-    // if (process.dev) {
-    //   // Only track in production
-    //   return
-    // }
-
     try {
       if (!account?.userInfo?.email || !account?.serverInfo?.url) {
         throw new Error('Email or server not found to track event.')
@@ -87,9 +81,9 @@ export function useAnalytics() {
       const response = await fetch(`https://${postHogApiHost as string}/i/v0/e/`, {
         method: 'POST',
         headers: {
-          'Content-Type': 'application/x-www-form-urlencoded'
+          'Content-Type': 'application/json'
         },
-        body: `data=${btoa(JSON.stringify(eventData))}`
+        body: JSON.stringify(eventData)
       })
 
       if (!response.ok) {

--- a/lib/core/composables/mixpanel.ts
+++ b/lib/core/composables/mixpanel.ts
@@ -1,58 +1,27 @@
-import md5 from '~/lib/common/helpers/md5'
 import { useHostAppStore } from '~/store/hostApp'
-import { useAccountStore } from '~/store/accounts'
-
+import type { Account } from '~/lib/bindings/definitions/IAccountBinding'
 interface CustomProperties {
   [key: string]: object | string | boolean | number | undefined | null
 }
 
-// Cached email, server, and userId
-const lastEmail: Ref<string | undefined> = ref(undefined)
-const lastServer: Ref<string | undefined> = ref(undefined)
-const lastUserId: Ref<string | undefined> = ref(undefined)
-
-/**
- * Get Mixpanel functions
- * In DUI3, quite likely to change distinct id of the track operation since we can trigger repetitive calls that belongs to different account.
- * Also we have some operations that explicitly not belong to any account, i.e. first "Send" or "Load" click,
- * with this case we use default account on manager to get "email", "server", and "userId" and cache them for later anonymous track.
- * In each call we update "lastEmail", "lastServer", and "lastUserId" for the following potential anonymous tracks.
- */
-export function useMixpanel() {
+export function useAnalytics() {
   const hostApp = useHostAppStore()
   const {
-    public: { mixpanelApiHost, mixpanelTokenId }
+    public: { postHogApiHost, postHogApiKey }
   } = useRuntimeConfig()
 
   /**
-   * Track event for mixpanel which do HTTP request to end point.
+   * Send metrics events to posthog
    * @param eventName Event name.
+   * @param account account track with
    * @param customProperties custom properties that will be attached to the properties of track event.
-   * @param accountId account id to track with id. It will populate hashed "distinct_id" from email and "server_id" from url.
-   * @param isAction whether event is action or not.
    */
   async function trackEvent(
     eventName: string,
+    account: Account,
     customProperties: CustomProperties = {},
-    accountId?: string,
-    isAction: boolean = true
+    workspaceId: string | null = null
   ) {
-    const { activeAccount, accounts } = useAccountStore()
-
-    if (accountId) {
-      const account = accounts.find((a) => a.accountInfo.id === accountId)
-      lastEmail.value = account?.accountInfo.userInfo.email
-      lastServer.value = account?.accountInfo.serverInfo.url
-      lastUserId.value = account?.accountInfo.userInfo.id
-    } else {
-      // do not set if they cached already
-      if (lastEmail.value === undefined || lastServer.value === undefined) {
-        lastEmail.value = activeAccount.accountInfo.userInfo.email
-        lastServer.value = activeAccount.accountInfo.serverInfo.url
-        lastUserId.value = activeAccount.accountInfo.userInfo.id
-      }
-    }
-
     // TODO: enable it later somehow
     // if (process.dev) {
     //   // Only track in production
@@ -60,14 +29,16 @@ export function useMixpanel() {
     // }
 
     try {
-      if (!lastEmail.value || !lastServer.value) {
+      if (!account?.userInfo?.email || !account?.serverInfo?.url) {
         throw new Error('Email or server not found to track event.')
       }
-      const hashedEmail =
-        '@' + md5(lastEmail.value.toLowerCase() as string).toUpperCase()
-      const serverUrl = new URL(lastServer.value)
-      const serverHostname = serverUrl.hostname.toLowerCase()
-      const hashedServer = md5(serverHostname).toUpperCase()
+
+      const url = new URL(account.serverInfo.url)
+
+      if (url === new URL('https://app.speckle.systems')) {
+        // Right now, we're keeping posthog only for app.speckle.systems users
+        return
+      }
 
       // Get os info from userAgent text
       // taken from original mixpanel implementation
@@ -79,120 +50,73 @@ export function useMixpanel() {
       } else if (/Mac/i.test(userAgent)) {
         os = 'Mac OS X'
       }
+      const [major, minor, patch] = _parseVersion(hostApp.connectorVersion)
 
-      // Merge base properties with custom ones
+      /* eslint-disable camelcase */
       const properties = {
         $os: os,
-        // eslint-disable-next-line camelcase
-        distinct_id: hashedEmail,
-        // eslint-disable-next-line camelcase
-        server_id: hashedServer,
-        // eslint-disable-next-line camelcase
-        server_domain: serverHostname,
-        token: mixpanelTokenId as string,
-        type: isAction ? 'action' : undefined,
-        hostApp: hostApp.hostAppName,
+        //$os_version: null,
+        $lib: 'speckle-connectors-dui',
+        $lib_version: '3',
+        $user_id: account.userInfo.id,
+        $session_id: hostApp.sessionId,
+        $host: url.host,
+        hostAppSlug: hostApp.hostAppName,
         hostAppVersion: hostApp.hostAppVersion as string,
-        ui: 'dui3', // Not sure about this but we need to put something to distiguish some events, like "Send", "Receive", alternatively we can have "SendDUI3" not sure!
-        // eslint-disable-next-line camelcase
-        core_version: hostApp.connectorVersion,
-        email: lastEmail.value,
-        userId: lastUserId.value,
+        connectorVersion: hostApp.connectorVersion,
+        connectorVersionMajor: major,
+        connectorVersionMinor: minor,
+        connectorVersionPatch: patch,
+        email: account.userInfo.email,
+        workspace_id: workspaceId,
         ...customProperties
       }
 
       const eventData = {
+        api_key: postHogApiKey,
         event: eventName.toString(),
+        distinct_id: account.userInfo.id,
         properties
       }
+      /* eslint-enable camelcase */
 
       if (import.meta.dev) {
-        console.info('Mixpanel event', eventData)
+        console.info('Posthog event', eventData)
       }
 
-      const response = await fetch(
-        `${mixpanelApiHost as string}/track?ip=1&_=${Date.now()}`,
-        {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded'
-          },
-          body: `data=${btoa(JSON.stringify(eventData))}`
-        }
-      )
-
-      if (!response.ok) {
-        throw new Error(`Analytics event failed: ${response.statusText}`)
-      }
-    } catch (error) {
-      // Handle error or logging
-      console.warn('Failed to track event in MixPanel:', error)
-    }
-  }
-
-  async function addConnectorToProfile(email: string) {
-    try {
-      const hashedEmail = '@' + md5(email.toLowerCase() as string).toUpperCase()
-
-      const eventData = {
-        // eslint-disable-next-line camelcase
-        $distinct_id: hashedEmail,
-        $token: mixpanelTokenId as string,
-        $union: {
-          Connectors: [hostApp.hostAppName]
-        }
-      }
-
-      const response = await fetch(
-        `${mixpanelApiHost as string}/engage#profile-union`,
-        {
-          method: 'POST',
-          headers: {
-            accept: 'text/plain',
-            'Content-Type': 'application/x-www-form-urlencoded'
-          },
-          body: `data=${btoa(JSON.stringify(eventData))}`
-        }
-      )
-      if (!response.ok) {
-        throw new Error(`Analytics event failed: ${response.statusText}`)
-      }
-    } catch (error) {
-      // Handle error or logging
-      console.warn('Failed to track event in MixPanel:', error)
-    }
-  }
-
-  async function identifyProfile(email: string) {
-    try {
-      const hashedEmail = '@' + md5(email.toLowerCase() as string).toUpperCase()
-
-      const eventData = {
-        // eslint-disable-next-line camelcase
-        $distinct_id: hashedEmail,
-        $token: mixpanelTokenId as string,
-        $set: {
-          Identified: true,
-          email
-        }
-      }
-
-      const response = await fetch(`${mixpanelApiHost as string}/engage#profile-set`, {
+      const response = await fetch(`https://${postHogApiHost as string}/i/v0/e/`, {
         method: 'POST',
         headers: {
-          accept: 'text/plain',
           'Content-Type': 'application/x-www-form-urlencoded'
         },
         body: `data=${btoa(JSON.stringify(eventData))}`
       })
+
       if (!response.ok) {
         throw new Error(`Analytics event failed: ${response.statusText}`)
       }
     } catch (error) {
       // Handle error or logging
-      console.warn('Failed to track event in MixPanel:', error)
+      console.warn('Failed to track event in PostHog:', error)
     }
   }
 
-  return { trackEvent, addConnectorToProfile, identifyProfile }
+  function _parseVersion(
+    applicationVersion: string | null | undefined
+  ): [number | null, number | null, number | null] {
+    if (!applicationVersion) {
+      return [null, null, null]
+    }
+
+    const coreVersion = applicationVersion.split('-')[0]
+    const [major, minor, patch] = coreVersion.split('.').map(Number)
+
+    if ([major, minor, patch].some(Number.isNaN)) {
+      throw new Error(`Invalid semantic version: ${applicationVersion}`)
+    }
+
+    return [major, minor, patch]
+  }
+
+  return { trackEvent }
 }

--- a/lib/core/composables/trackSettings.ts
+++ b/lib/core/composables/trackSettings.ts
@@ -1,8 +1,8 @@
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import type { CardSetting } from '~/lib/models/card/setting'
 
 export function useSettingsTracking() {
-  const { trackEvent } = useMixpanel()
+  const { trackEvent } = useAnalytics()
 
   function trackSettingsChange(
     eventName: string,
@@ -31,7 +31,7 @@ export function useSettingsTracking() {
           : setting.value
       }
     })
-
+    
     // only track if user changed a setting
     if (!requireChanges || hasAnyChange) {
       void trackEvent('DUI3 Action', settingProperties, accountId)

--- a/lib/core/composables/trackSettings.ts
+++ b/lib/core/composables/trackSettings.ts
@@ -1,4 +1,5 @@
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
+import type { Account } from '~/lib/bindings/definitions/IAccountBinding'
 import type { CardSetting } from '~/lib/models/card/setting'
 
 export function useSettingsTracking() {
@@ -8,8 +9,9 @@ export function useSettingsTracking() {
     eventName: string,
     settings: CardSetting[],
     defaultSettings: CardSetting[],
-    accountId?: string,
-    requireChanges: boolean = false
+    account?: Account,
+    requireChanges: boolean = false,
+    workspaceId?: string | null
   ) {
     // building dynamic properties
     // since this can change based on HostApp
@@ -33,8 +35,8 @@ export function useSettingsTracking() {
     })
     
     // only track if user changed a setting
-    if (!requireChanges || hasAnyChange) {
-      void trackEvent('DUI3 Action', settingProperties, accountId)
+    if (account && (!requireChanges || hasAnyChange)) {
+      void trackEvent('DUI3 Action', account, settingProperties, workspaceId)
     }
   }
 

--- a/lib/core/composables/trackSettings.ts
+++ b/lib/core/composables/trackSettings.ts
@@ -33,7 +33,7 @@ export function useSettingsTracking() {
           : setting.value
       }
     })
-    
+
     // only track if user changed a setting
     if (account && (!requireChanges || hasAnyChange)) {
       void trackEvent('DUI3 Action', account, settingProperties, workspaceId)

--- a/lib/core/utils/hyperdx.ts
+++ b/lib/core/utils/hyperdx.ts
@@ -8,7 +8,7 @@
  *
  * Config is baked at build time via `NUXT_PUBLIC_HYPERDX_*` and exposed through
  * `runtimeConfig.public` (see `nuxt.config.ts`), the same way the DUI already
- * injects Mixpanel config.
+ * injects PostHog config.
  */
 type HyperDXModule = typeof import('@hyperdx/browser')
 let hyperdx: HyperDXModule['default'] | null = null

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -20,8 +20,8 @@ export default defineNuxtConfig({
 
   runtimeConfig: {
     public: {
-      mixpanelApiHost: 'UNDEFINED',
-      mixpanelTokenId: 'UNDEFINED',
+      postHogApiKey: process.env.NUXT_PUBLIC_POSTHOG_API_KEY || '',
+      postHogApiHost: process.env.NUXT_PUBLIC_POSTHOG_API_HOST || '',
       speckleToken: process.env.SPECKLE_TOKEN,
       speckleUserId: process.env.SPECKLE_USER_ID,
       speckleUserEmail: process.env.SPECKLE_USER_EMAIL,

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -218,7 +218,7 @@ import {
 import { useAccountStore } from '~~/store/accounts'
 import { useHostAppStore } from '~~/store/hostApp'
 import { useConfigStore } from '~~/store/config'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 const app = useNuxtApp()
 const config = useConfigStore()
 
@@ -231,7 +231,7 @@ await accountStore.refreshAccounts()
 const { accounts } = storeToRefs(accountStore)
 
 const store = useHostAppStore()
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 
 const showSendDialog = ref(false)
 const showReceiveDialog = ref(false)

--- a/pages/index.vue
+++ b/pages/index.vue
@@ -218,7 +218,6 @@ import {
 import { useAccountStore } from '~~/store/accounts'
 import { useHostAppStore } from '~~/store/hostApp'
 import { useConfigStore } from '~~/store/config'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 const app = useNuxtApp()
 const config = useConfigStore()
 
@@ -231,7 +230,6 @@ await accountStore.refreshAccounts()
 const { accounts } = storeToRefs(accountStore)
 
 const store = useHostAppStore()
-const { trackEvent } = useAnalytics()
 
 const showSendDialog = ref(false)
 const showReceiveDialog = ref(false)
@@ -243,12 +241,10 @@ app.$baseBinding?.on('documentChanged', () => {
 
 const handleSendClick = () => {
   showSendDialog.value = !showSendDialog.value
-  trackEvent('DUI3 Action', { name: 'Publish Wizard', step: 'start' })
 }
 
 const handleReceiveClick = () => {
   showReceiveDialog.value = !showReceiveDialog.value
-  trackEvent('DUI3 Action', { name: 'Load Wizard', step: 'start' })
 }
 
 const hasNoModelCards = computed(

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -202,13 +202,13 @@ import type {
 
 // Import categories
 import { getAvailableCategories, getCategoryLabel } from '~/lib/mapper/revit-categories'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 
 // === STORES ===
 const selectionStore = useSelectionStore()
 const revitMapperStore = useRevitMapper()
 const { selectionInfo } = storeToRefs(selectionStore)
-const { trackEvent } = useMixpanel()
+const { trackEvent } = useAnalytics()
 
 // === STATE ===
 const selectedMappingMode = ref<string | undefined>(undefined)
@@ -343,34 +343,15 @@ const assignToCategory = async () => {
   if (!revitMapperStore.selectedCategory?.value || !hasTargetsSelected.value) return
 
   try {
-    let assignedCount = 0
     const { selectedCategory } = storeToRefs(revitMapperStore)
     const categoryValue = selectedCategory?.value?.value
 
     if (selectedMappingMode.value === 'Selection' && categoryValue) {
       const objectIds = selectionInfo.value?.selectedObjectIds || []
       await $revitMapperBinding?.assignObjectsToCategory(objectIds, categoryValue)
-      assignedCount = objectIds.length
-
-      // Track the assignment
-      trackEvent('DUI3 Action', {
-        name: 'Mapper Assign Category',
-        category: categoryValue,
-        count: assignedCount,
-        mappingType: 'object'
-      })
     } else if (selectedMappingMode.value === 'Layer' && categoryValue) {
       const layerIds = selectedLayers.value.map((layer) => layer.id)
       await $revitMapperBinding?.assignLayerToCategory(layerIds, categoryValue)
-      assignedCount = selectedLayers.value.length
-
-      // Track the assignment
-      trackEvent('DUI3 Action', {
-        name: 'Mapper Assign Category',
-        category: categoryValue,
-        count: assignedCount,
-        mappingType: 'layer'
-      })
 
       selectedLayers.value = []
     }
@@ -667,12 +648,6 @@ onMounted(async () => {
   $revitMapperBinding?.on('layersChanged', (newLayers: LayerOption[]) => {
     layerOptions.value = newLayers
     selectedLayers.value = []
-  })
-
-  // Track mapper opened with the initial mode (after loadData determines it)
-  trackEvent('DUI3 Action', {
-    name: 'Mapper Opened',
-    mode: selectedMappingMode.value
   })
 })
 

--- a/pages/revit-mapper.vue
+++ b/pages/revit-mapper.vue
@@ -202,13 +202,11 @@ import type {
 
 // Import categories
 import { getAvailableCategories, getCategoryLabel } from '~/lib/mapper/revit-categories'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
 
 // === STORES ===
 const selectionStore = useSelectionStore()
 const revitMapperStore = useRevitMapper()
 const { selectionInfo } = storeToRefs(selectionStore)
-const { trackEvent } = useAnalytics()
 
 // === STATE ===
 const selectedMappingMode = ref<string | undefined>(undefined)
@@ -318,12 +316,6 @@ const confirmModeChange = async () => {
       // Clear all layer mappings before switching to Selection mode
       await $revitMapperBinding?.clearAllLayerCategoryAssignments()
     }
-
-    // Track the manual mode switch
-    trackEvent('DUI3 Action', {
-      name: 'Mapper Mode Changed',
-      mode: selectedMappingMode.value
-    })
 
     // Switch mode
     selectedMappingMode.value = pendingMode.value

--- a/store/accounts.ts
+++ b/store/accounts.ts
@@ -309,6 +309,12 @@ export const useAccountStore = defineStore('accountStore', () => {
     ).client
   }
 
+  const getAccount = (accountId: string): DUIAccount | undefined => {
+    return accounts.value.find(
+      (account) => account.accountInfo.id === accountId
+    ) as DUIAccount
+  }
+
   const provideClients = () => {
     provideApolloClients(apolloClients)
   }
@@ -336,6 +342,7 @@ export const useAccountStore = defineStore('accountStore', () => {
     isLoading,
     accounts,
     getAccountClient,
+    getAccount,
     defaultAccount,
     activeAccount,
     userSelectedAccount,

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -3,7 +3,7 @@ import type {
   DocumentModelStore
 } from '~/lib/bindings/definitions/IBasicConnectorBinding'
 import type { IModelCard, ModelCardProgress } from '~/lib/models/card'
-import { useAnalytics } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/analytics'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
 import type {
   IDirectSelectionSendFilter,
@@ -449,12 +449,21 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     const account = accountsStore.getAccount(model.accountId)
 
     if (account) {
+      const settingProperties = Object.fromEntries(
+        (model.settings ?? []).map((setting) => [
+          `ModelCardSetting_${setting.id}`,
+          setting.value
+        ])
+      )
+
       void trackEvent(
         'Send',
         account.accountInfo,
         {
           expired: model.expired,
-          actionSource: actionSource.toLowerCase()
+          actionSource: actionSource.toLowerCase(),
+          sendFilter: model.sendFilter?.name,
+          ...settingProperties
         },
         model.workspaceId
       )

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -451,7 +451,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     if (account) {
       const settingProperties = Object.fromEntries(
         (model.settings ?? []).map((setting) => [
-          `ModelCardSetting_${setting.id}`,
+          `modelCardSetting_${setting.id}`,
           setting.value
         ])
       )

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -3,7 +3,7 @@ import type {
   DocumentModelStore
 } from '~/lib/bindings/definitions/IBasicConnectorBinding'
 import type { IModelCard, ModelCardProgress } from '~/lib/models/card'
-import { useMixpanel } from '~/lib/core/composables/mixpanel'
+import { useAnalytics } from '~/lib/core/composables/mixpanel'
 import type { IReceiverModelCard } from '~/lib/models/card/receiver'
 import type {
   IDirectSelectionSendFilter,
@@ -45,7 +45,7 @@ export type ProjectModelGroup = {
 
 export const useHostAppStore = defineStore('hostAppStore', () => {
   const app = useNuxtApp()
-  const { trackEvent } = useMixpanel()
+  const { trackEvent } = useAnalytics()
   const { $openUrl } = useNuxtApp()
   const accountsStore = useAccountStore()
   const { checkUpdate } = useUpdateConnector()
@@ -76,6 +76,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
 
   const isUpdateNotificationDisabled = ref(false)
   const defaultSpeckleServerUrl = ref('https://app.speckle.systems')
+  const sessionId = ref<Nullable<string>>()
 
   // Different host apps can have different kind of ISendFilterSelect send filters, and we collect them here to generalize the component we use in `ListSelect`
   const availableSelectSendFilters = ref<Record<string, SendFilterSelect>>({})
@@ -193,12 +194,6 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     documentModelStore.value.models = documentModelStore.value.models.filter(
       (item) => item.modelCardId !== model.modelCardId
     )
-
-    void trackEvent(
-      'DUI3 Action',
-      { name: 'Remove Model Card', type: model.typeDiscriminator },
-      model.accountId
-    )
   }
 
   const removeAccountModels = async (accountId: string) => {
@@ -252,8 +247,17 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     ) as ISenderModelCard
     model.progress = undefined
     model.error = undefined
-    void trackEvent('DUI3 Action', { name: 'Send Cancel' }, model.accountId)
     model.latestCreatedVersionId = undefined
+
+    const account = accountsStore.getAccount(model.accountId)
+    if (account) {
+      void trackEvent(
+        'DUI3 Action',
+        account.accountInfo,
+        { name: 'Send Cancel' },
+        model.workspaceId
+      )
+    }
   })
 
   app.$sendBinding?.on(
@@ -442,28 +446,17 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     model.expired = false
     model.report = undefined
 
-    if (model.expired) {
-      // user sends via "Update" button
+    const account = accountsStore.getAccount(model.accountId)
+
+    if (account) {
       void trackEvent(
         'Send',
+        account.accountInfo,
         {
-          expired: true,
-          actionSource: actionSource.toLowerCase(),
-          // eslint-disable-next-line camelcase
-          workspace_id: model.workspaceId
+          expired: model.expired,
+          actionSource: actionSource.toLowerCase()
         },
-        model.accountId
-      )
-    } else {
-      void trackEvent(
-        'Send',
-        {
-          expired: false,
-          actionSource: actionSource.toLowerCase(),
-          // eslint-disable-next-line camelcase
-          workspace_id: model.workspaceId
-        },
-        model.accountId
+        model.workspaceId
       )
     }
 
@@ -491,8 +484,17 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await app.$sendBinding.cancelSend(modelCardId)
     model.progress = undefined
     model.error = undefined
-    void trackEvent('DUI3 Action', { name: 'Send Cancel' }, model.accountId)
     model.latestCreatedVersionId = undefined
+
+    const account = accountsStore.getAccount(model.accountId)
+    if (account) {
+      void trackEvent(
+        'DUI3 Action',
+        account.accountInfo,
+        { name: 'Send Cancel' },
+        model.workspaceId
+      )
+    }
 
     // Clean up any active ingestion subscription from SDK-based connectors
     unsubscribeFromIngestion(modelCardId)
@@ -555,23 +557,21 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       (m) => m.modelCardId === modelCardId
     ) as IReceiverModelCard
 
-    const account = accountsStore.accounts.find(
-      (a) => a.accountInfo.id === model.accountId
-    )
-
-    void trackEvent(
-      'Receive',
-      {
-        expired: model.expired,
-        sourceHostApp: model.selectedVersionSourceApp,
-        isMultiplayer: model.selectedVersionUserId !== account?.accountInfo.userInfo.id,
-        actionSource: actionSource.toLowerCase(),
-        // eslint-disable-next-line camelcase
-        workspace_id: model.workspaceId
-      },
-      model.accountId
-    )
-
+    const account = accountsStore.getAccount(model.accountId)
+    if (account) {
+      void trackEvent(
+        'Receive',
+        account.accountInfo,
+        {
+          expired: model.expired,
+          sourceHostApp: model.selectedVersionSourceApp,
+          isMultiplayer:
+            model.selectedVersionUserId !== account.accountInfo.userInfo.id,
+          actionSource: actionSource.toLowerCase()
+        },
+        model.workspaceId
+      )
+    }
     model.report = undefined
     model.error = undefined
     model.expired = false
@@ -597,8 +597,17 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       (m) => m.modelCardId === modelCardId
     ) as IReceiverModelCard
     await app.$receiveBinding.cancelReceive(modelCardId)
-    void trackEvent('DUI3 Action', { name: 'Receive Cancel' }, model.accountId)
     model.progress = undefined
+
+    const account = accountsStore.getAccount(model.accountId)
+    if (account) {
+      void trackEvent(
+        'DUI3 Action',
+        account.accountInfo,
+        { name: 'Receive Cancel' },
+        model.workspaceId
+      )
+    }
   }
 
   const setModelReceiveResult = async (args: {
@@ -733,6 +742,18 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     if (app.$isRunningOnConnector && !isUpdateNotificationDisabled.value) {
       await checkUpdate()
     }
+  }
+
+  const getSessionId = async () => {
+    const canGetSessionId = ['getSessionId', 'GetSessionId'].some((name) =>
+      (app.$configBinding as unknown as BaseBridge).availableMethodNames.includes(name)
+    )
+
+    if (canGetSessionId) {
+      sessionId.value = await app.$configBinding.getSessionId()
+    }
+
+    return null
   }
 
   /**
@@ -913,6 +934,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     await getHostAppName()
     await getHostAppVersion()
     await getConnectorVersion()
+    await getSessionId()
     await refreshDocumentInfo()
     await refreshDocumentModelStore()
     await refreshSendFilters()
@@ -945,6 +967,7 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
     hostAppName,
     hostAppVersion,
     connectorVersion,
+    sessionId,
     activeIngestions,
     isConnectorUpToDate,
     latestAvailableVersion,


### PR DESCRIPTION
Migrate from mixpanel to posthog

Sample of track:
- [Receive](https://eu.posthog.com/project/103660/events/019f3819-7db0-77ae-a8a9-30f3876bc609/2026-07-06T15%3A43%3A42.512000Z)
- [Send](https://eu.posthog.com/project/103660/events/019f3819-5e4d-7975-b0c2-f866586f0bd1/2026-07-06T15%3A43%3A34.477000Z)

Diff of events we now track:
```diff
  DUI Account Added
- Feedback Sent
  Send
  Receive
  DUI3 Action / Send Cancel
  DUI3 Action / Receive Cancel
  DUI3 Action / Highlight Model
  DUI3 Action / Version View
- DUI3 Action / Comment View
- DUI3 Action / Model History View
  DUI3 Action / Set version message
  DUI3 Action / Publish Card Filter Change
- DUI3 Action / Load Card Version Change
- DUI3 Action / Project View
  DUI3 Action / Account Select
  DUI3 Action / Project Create
  DUI3 Action / Model Create
  DUI3 Action / Publish Settings Changed
  DUI3 Action / Load Settings Changed
- DUI3 Action / Launch
- DUI3 Action / Account menu open
- DUI3 Action / Account change
- DUI3 Action / Account removed
- DUI3 Action / Remove Model Card
- DUI3 Action / Mapper Assign Category
- DUI3 Action / Mapper Opened
- DUI3 Action / Mapper Mode Changed
- DUI3 Action / Publish Wizard
- DUI3 Action / Load Wizard
```

Also removed `AddConnectorToProfile`, We can bring back something similar with posthog, but it may be `groups` which need configuration. I've decided not to do this for now, but we can reconsider if we think it's important.