### PR TITLE
Feat: Include error in binding faliure

### DIFF
--- a/lib/bridge/generic.ts
+++ b/lib/bridge/generic.ts
@@ -34,8 +34,8 @@ export class GenericBridge extends BaseBridge {
 
     try {
       this.availableMethodNames = await this.bridge.GetBindingsMethodNames()
-    } catch {
-      console.warn(`Failed to get method names from binding.`)
+    } catch (error) {
+      console.warn(`Failed to get method names from binding.`, error)
       return false
     }
 


### PR DESCRIPTION
Investigating a potential DLL conflict in Revit 2024 that's causing UI to fail to communicate with .NET
This PR ensures the real error gets propagated to the warning

Before:
<img width="218" height="26" alt="image" src="https://github.com/user-attachments/assets/c2f4d651-3fdf-45f9-b3c1-bcf9a438e309" />

After:
<img width="362" height="38" alt="image" src="https://github.com/user-attachments/assets/3d8e2f18-90f6-4766-95fe-1bbeeb1bb0f4" />
