### PR TITLE
fix: skip Intercom permission check on servers without workspaces module

### DIFF
--- a/plugins/intercom.client.ts
+++ b/plugins/intercom.client.ts
@@ -86,9 +86,15 @@ export const useIntercom = () => {
   }
 
   const checkPermissions = async () => {
-    if (!activeAccount.value || !userSelectedWorkspaceId.value) {
+    if (
+      !activeAccount.value ||
+      !userSelectedWorkspaceId.value ||
+      !activeAccount.value.workspacesEnabled
+    ) {
       // userSelectedWorkspaceId is only null before any publish/load action,
-      // at which point the NavBar (and feedback button) isn't visible anyway
+      // at which point the NavBar (and feedback button) isn't visible anyway.
+      // Servers without the workspaces module (most self-hosted servers) don't
+      // expose this query at all, so skip it rather than let it fail with a 400.
       hasIntercomAccess.value = false
       return
     }

--- a/store/accounts.ts
+++ b/store/accounts.ts
@@ -17,6 +17,7 @@ import { setContext } from '@apollo/client/link/context'
 import { useHostAppStore } from '~/store/hostApp'
 import { ToastNotificationType } from '@speckle/ui-components'
 import { logToSeq } from '~/lib/logger/composables/useLogger'
+import { serverInfoQuery } from '~/lib/graphql/mutationsAndQueries'
 
 export type DUIAccount = {
   /** account info coming from the host app */
@@ -25,6 +26,8 @@ export type DUIAccount = {
   client: ApolloClient<unknown>
   /** whether an intial serverinfo query succeeded. */
   isValid: boolean
+  /** whether this account's server has the workspaces module enabled (false on most self-hosted servers) */
+  workspacesEnabled: boolean
 }
 
 const accountTestQuery = gql`
@@ -203,20 +206,23 @@ export const useAccountStore = defineStore('accountStore', () => {
         }
       })
 
-      // const workspacesEnabled = false
-      // try {
-      //   // get workspace enabled flag and store it in account
-      //   const res = await client.query({ query: serverInfoQuery })
-      //   workspacesEnabled = !!res.data.serverInfo.workspaces.workspacesEnabled
-      // } catch (err) {
-      //   // probably having some local account or client could not established well for some reason!
-      //   console.log(err)
-      // }
+      let workspacesEnabled = false
+      try {
+        // get workspace enabled flag and store it in account
+        const res = await client.query({ query: serverInfoQuery })
+        workspacesEnabled = !!res.data.serverInfo.workspaces.workspacesEnabled
+      } catch (err) {
+        // servers without the workspaces module (e.g. self-hosted with
+        // FF_WORKSPACES_MODULE_ENABLED=false) don't expose `serverInfo.workspaces`
+        // in their schema at all, so this query fails - that's expected, treat as disabled
+        console.log(err)
+      }
 
       apolloClients[acc.id] = client
       newAccs.push({
         accountInfo: acc,
         client,
+        workspacesEnabled,
         isValid: true
       })
     }


### PR DESCRIPTION
## Summary
- `checkPermissions()` in `plugins/intercom.client.ts` always fires `workspaceIntercomPermissionQuery`, regardless of whether the target server supports workspaces.
- Self-hosted servers with `FF_WORKSPACES_MODULE_ENABLED=false` don't expose `workspace` in their GraphQL schema at all, so the query fails with a hard `400` on every account/workspace change. The error is already caught (`hasIntercomAccess` just ends up `false`), but it's noisy in the console on every connector launch for self-hosted users, and it's a wasted network round trip.
- `store/accounts.ts` already had a `serverInfoQuery` call for exactly this (`workspacesEnabled`) written but commented out and unused. This PR wires it up: records `workspacesEnabled` per account in `refreshAccounts()`, and has `checkPermissions()` skip the query entirely when the active account's server doesn't support workspaces.
- Same `serverInfo.workspaces.workspacesEnabled` check already gates the workspace picker UI in `components/wizard/ProjectSelector.vue`, so this follows an existing, established pattern rather than introducing a new one.

## Test plan
- [ ] Verify against a self-hosted server with `FF_WORKSPACES_MODULE_ENABLED=false`: no more `400` on `/graphql` for the Intercom permission check, no console warning.
- [ ] Verify against app.speckle.systems (workspaces enabled): Intercom still boots/behaves as before for eligible accounts.
- [ ] `yarn lint:tsc` passes (only one construction site for `DUIAccount` exists, in `refreshAccounts()`, now updated to include `workspacesEnabled`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/specklesystems/codesmith/speckle-connectors-dui/pr/121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787741244&installation_model_id=3962&pr_number=121&repository=specklesystems%2Fspeckle-connectors-dui&return_to=https%3A%2F%2Fgithub.com%2Fspecklesystems%2Fspeckle-connectors-dui%2Fpull%2F121&signature=e903cf61871615df6860388c2df7d66efeba9fdf1a3c73ee1a82bd3a1842320a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->