### PR TITLE
fix(send): one DUI-owned ingestion per publish for 4.0 artifact sends…

### DIFF
--- a/components/common/ProjectModelGroup.vue
+++ b/components/common/ProjectModelGroup.vue
@@ -81,9 +81,10 @@
     >
       <template #title>
         <span v-if="inaccessibleReason === 'no-account'">
-          <!-- no local account matches this project's server — query was never attempted -->
+          <!-- no local account matches this project's server — query was never attempted.
+               serverUrl can be missing on cards saved by older connectors -->
           No account found for
-          <code>{{ project.serverUrl }}</code>
+          <code>{{ project.serverUrl || 'this project’s server (unknown)' }}</code>
         </span>
         <span v-else>
           <!-- project query threw — server will throw for any reason the account can't see
@@ -152,7 +153,10 @@ const projectNavigatorTippy = computed(() =>
     : 'Open project in browser'
 )
 
-const normalizeUrl = (url: string) => url.replace(/\/$/, '').toLowerCase()
+// null-tolerant: model cards saved by older connectors restore without a
+// serverUrl, and stale accounts can miss serverInfo.url
+const normalizeUrl = (url: string | null | undefined) =>
+  (url ?? '').replace(/\/$/, '').toLowerCase()
 
 // match by account ID first, then fall back to server URL
 // normalized to avoid trailing-slash / casing mismatches (can that even be a thing??)

--- a/lib/bindings/definitions/ISendBinding.ts
+++ b/lib/bindings/definitions/ISendBinding.ts
@@ -16,7 +16,19 @@ export const ISendBindingKey = 'sendBinding'
 export interface ISendBinding extends IBinding<ISendBindingEvents> {
   getSendFilters: () => Promise<ISendFilter[]>
   getSendSettings: () => Promise<CardSetting[]>
-  send: (modelId: string) => Promise<void>
+  /**
+   * The optional ingestion args carry the DUI-created ingestion (and its
+   * pre-allocated version id) down to connectors on the 4.0 artifact path
+   * (today: sketchup) — one ingestion per publish, created by the DUI; the
+   * server creates the version and the DUI tracks it via the ingestion
+   * subscription. Only passed for hosts whose bridge forwards variadic args;
+   * other connectors keep receiving a single argument.
+   */
+  send: (
+    modelId: string,
+    ingestionId?: string,
+    ingestionVersionId?: string
+  ) => Promise<void>
   cancelSend: (modelId: string) => Promise<void>
 }
 

--- a/lib/ingestion/composables/useModelIngestion.ts
+++ b/lib/ingestion/composables/useModelIngestion.ts
@@ -38,6 +38,11 @@ import { ToastNotificationType } from '@speckle/ui-components'
  * schema yet — callers must tolerate it failing on older servers. Built via
  * `parse` (not a `gql` tag) so graphql-codegen's document scanner does not
  * pick it up and fail validation against the production schema.
+ *
+ * TODO(ENG-9043): once production exposes ModelIngestion.versionId, select it
+ * directly in the CreateModelIngestion mutation and delete this probe (and its
+ * extra roundtrip in startIngestion) — failure tolerance then becomes a plain
+ * optional-field read on the mutation response.
  */
 const preallocatedVersionIdQuery = parse(`
   query IngestionPreallocatedVersionId($projectId: String!, $ingestionId: ID!) {

--- a/lib/ingestion/composables/useModelIngestion.ts
+++ b/lib/ingestion/composables/useModelIngestion.ts
@@ -3,7 +3,7 @@ import {
   useMutation,
   useSubscription
 } from '@vue/apollo-composable'
-import { gql } from '@apollo/client/core'
+import { parse } from 'graphql'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 import {
@@ -35,9 +35,11 @@ import { ToastNotificationType } from '@speckle/ui-components'
  * Raw (non-codegen) query for the version id the server pre-allocates on
  * ingestion create. `ModelIngestion.versionId` only exists on 4.0 (v2 data
  * endpoint) servers, so this cannot go through codegen against the production
- * schema yet — callers must tolerate it failing on older servers.
+ * schema yet — callers must tolerate it failing on older servers. Built via
+ * `parse` (not a `gql` tag) so graphql-codegen's document scanner does not
+ * pick it up and fail validation against the production schema.
  */
-const preallocatedVersionIdQuery = gql`
+const preallocatedVersionIdQuery = parse(`
   query IngestionPreallocatedVersionId($projectId: String!, $ingestionId: ID!) {
     project(id: $projectId) {
       id
@@ -47,7 +49,7 @@ const preallocatedVersionIdQuery = gql`
       }
     }
   }
-`
+`)
 
 export const useModelIngestion = () => {
   const store = useHostAppStore()

--- a/lib/ingestion/composables/useModelIngestion.ts
+++ b/lib/ingestion/composables/useModelIngestion.ts
@@ -3,6 +3,7 @@ import {
   useMutation,
   useSubscription
 } from '@vue/apollo-composable'
+import { gql } from '@apollo/client/core'
 import { useAccountStore } from '~/store/accounts'
 import { useHostAppStore } from '~/store/hostApp'
 import {
@@ -30,6 +31,24 @@ import { ToastNotificationType } from '@speckle/ui-components'
  * 2. Update the ingestion with the new data when connector throws progress via 'setModelProgress' event
  * 3. Complete the version with the root object id that passed by connector or server/sketchup bridges in JS
  */
+/**
+ * Raw (non-codegen) query for the version id the server pre-allocates on
+ * ingestion create. `ModelIngestion.versionId` only exists on 4.0 (v2 data
+ * endpoint) servers, so this cannot go through codegen against the production
+ * schema yet — callers must tolerate it failing on older servers.
+ */
+const preallocatedVersionIdQuery = gql`
+  query IngestionPreallocatedVersionId($projectId: String!, $ingestionId: ID!) {
+    project(id: $projectId) {
+      id
+      ingestion(id: $ingestionId) {
+        id
+        versionId
+      }
+    }
+  }
+`
+
 export const useModelIngestion = () => {
   const store = useHostAppStore()
 
@@ -71,7 +90,29 @@ export const useModelIngestion = () => {
       activeIngestions.value[senderModelCard.modelCardId] = ingestionId
     }
 
-    return res?.data?.projectMutations.modelIngestionMutations.create
+    // On 4.0 servers the ingestion comes with a pre-allocated version id, which
+    // connectors on the artifact path need up-front (artifact filenames bake it
+    // in). Older servers don't have the field — treat that as "not available".
+    let preallocatedVersionId: string | undefined
+    if (ingestionId) {
+      try {
+        const versionRes = await client.query<{
+          project?: { ingestion?: { versionId?: string | null } | null }
+        }>({
+          query: preallocatedVersionIdQuery,
+          variables: { projectId: senderModelCard.projectId, ingestionId },
+          fetchPolicy: 'network-only'
+        })
+        preallocatedVersionId =
+          versionRes.data?.project?.ingestion?.versionId ?? undefined
+      } catch {
+        // Older server without ModelIngestion.versionId — artifact-path callers
+        // will send without ingestion info and surface a clear connector error.
+      }
+    }
+
+    const created = res?.data?.projectMutations.modelIngestionMutations.create
+    return created ? { ...created, preallocatedVersionId } : created
   }
 
   const updateIngestion = async (

--- a/store/hostApp.ts
+++ b/store/hostApp.ts
@@ -406,6 +406,11 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       model.accountId
     )
 
+    // The DUI-created ingestion handed down to connectors on the 4.0 artifact
+    // path (sketchup): they extract/upload against it and the DUI completes it —
+    // one ingestion per publish, owned by the DUI end-to-end.
+    let connectorIngestion: { ingestionId: string; versionId: string } | undefined
+
     // for the connectors that don't have SDK to handle graqhql
     if (shouldHandleIngestion.value && canCreateIngestion.queryAvailable) {
       const sourceData = {
@@ -413,7 +418,13 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
         sourceApplicationVersion: hostAppVersion.value?.toString() || 'unknown'
       }
       if (canCreateIngestion.authorized) {
-        await startIngestion(model, 'Starting to publish', sourceData)
+        const created = await startIngestion(model, 'Starting to publish', sourceData)
+        if (created?.id && created.preallocatedVersionId) {
+          connectorIngestion = {
+            ingestionId: created.id,
+            versionId: created.preallocatedVersionId
+          }
+        }
         model.progress = { status: 'Converting the objects...' }
       } else {
         setNotification({
@@ -477,6 +488,23 @@ export const useHostAppStore = defineStore('hostAppStore', () => {
       setTimeout(() => {
         void app.$sendBinding.send(modelCardId)
       }, 500) // I prefer to sacrifice 500ms
+    } else if (
+      hostAppName.value === 'sketchup' &&
+      connectorIngestion &&
+      // Evergreen-DUI guard: only 4.0 connectors register the 'sendArtifacts'
+      // command; older connectors have a fixed-arity `send` that would error on
+      // extra args, so they keep getting the single-argument call.
+      (app.$sendBinding as unknown as BaseBridge).availableMethodNames?.includes(
+        'sendArtifacts'
+      )
+    ) {
+      // Sketchup's bridge forwards variadic args to Ruby: the artifact path
+      // uploads against this DUI-created ingestion instead of creating its own.
+      void app.$sendBinding.send(
+        modelCardId,
+        connectorIngestion.ingestionId,
+        connectorIngestion.versionId
+      )
     } else {
       void app.$sendBinding.send(modelCardId)
     }


### PR DESCRIPTION
… (ENG-9043)

The sketchup 4.0 artifact path created its own ingestion in Ruby while the DUI had already started one, and reported the pre-allocated versionId as a created version — showing the 'View' CTA before the version existed (the server only creates it after the datgen job builds the viewer .dat).

Now the DUI creates the single ingestion, fetches its pre-allocated versionId (tolerant raw query — the field only exists on v2 servers), and hands both down to the connector via optional variadic send args. The connector uploads against that ingestion and echoes the ingestionId back in setModelSendResult, so the existing subscription flow keeps the card in progress until the server reports success — 'View' only appears once the version truly exists.

Evergreen-safe: the versionId probe degrades to undefined on older servers, and the 3-arg send is gated on the connector registering 'sendArtifacts' (older connectors have a fixed-arity send and keep the single-arg call).